### PR TITLE
Feature: Team/Objectives modifies current confidence calculation

### DIFF
--- a/src/domain/key-result/service.ts
+++ b/src/domain/key-result/service.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { sum, uniq } from 'lodash'
+import { sum, min, uniq } from 'lodash'
 
 import { TIMEFRAME_SCOPE } from 'domain/constants'
 import { KeyResultDTO } from 'domain/key-result/dto'
@@ -146,15 +146,14 @@ class DomainKeyResultService extends DomainEntityService<KeyResult, KeyResultDTO
     return calculatedSnapshotProgress
   }
 
-  async calculateAverageCurrentConfidenceFromList(keyResults: KeyResult[]) {
+  async getLowestConfidenceFromList(keyResults: KeyResult[]) {
+    const defaultConfidence = 100
     const currentConfidenceList = await Promise.all(
       keyResults.map(async ({ id }) => this.getCurrentConfidence(id)),
     )
-    const currentConfidence = sum(currentConfidenceList) / currentConfidenceList.length
+    const minConfidence = min(currentConfidenceList)
 
-    const normalizedCurrentConfidence = Number.isNaN(currentConfidence) ? 100 : currentConfidence
-
-    return normalizedCurrentConfidence
+    return minConfidence ?? defaultConfidence
   }
 }
 

--- a/src/domain/objective/service.ts
+++ b/src/domain/objective/service.ts
@@ -82,9 +82,7 @@ class DomainObjectiveService extends DomainEntityService<Objective, ObjectiveDTO
     const keyResults = await this.keyResultService.getFromObjective(objectiveId)
     if (!keyResults) return
 
-    const objectiveCurrentConfidence = this.keyResultService.calculateAverageCurrentConfidenceFromList(
-      keyResults,
-    )
+    const objectiveCurrentConfidence = this.keyResultService.getLowestConfidenceFromList(keyResults)
 
     return objectiveCurrentConfidence
   }

--- a/src/domain/team/service.ts
+++ b/src/domain/team/service.ts
@@ -82,15 +82,14 @@ class DomainTeamService extends DomainEntityService<Team, TeamDTO> {
   }
 
   async getCurrentConfidence(teamId: TeamDTO['id']): Promise<ConfidenceReport['valueNew']> {
+    const defaultConfidence = 100
     const childTeams = await this.getChildTeams(teamId, ['id'])
     const childTeamIds = childTeams.map((childTeam) => childTeam.id)
 
     const keyResults = await this.keyResultService.getFromTeam(childTeamIds)
-    if (!keyResults) return
+    if (!keyResults) return defaultConfidence
 
-    const teamCurrentConfidence = this.keyResultService.calculateAverageCurrentConfidenceFromList(
-      keyResults,
-    )
+    const teamCurrentConfidence = this.keyResultService.getLowestConfidenceFromList(keyResults)
 
     return teamCurrentConfidence
   }


### PR DESCRIPTION
## ☕ Purpose

This PR updates the calculation of current confidence for teams and objectives to use the minimum confidence instead of the average.