### PR TITLE
Bugfix: Teams - Current Confidence ignoring deep children

### DIFF
--- a/src/domain/team/service.ts
+++ b/src/domain/team/service.ts
@@ -83,10 +83,11 @@ class DomainTeamService extends DomainEntityService<Team, TeamDTO> {
 
   async getCurrentConfidence(teamId: TeamDTO['id']): Promise<ConfidenceReport['valueNew']> {
     const defaultConfidence = 100
-    const childTeams = await this.getChildTeams(teamId, ['id'])
-    const childTeamIds = childTeams.map((childTeam) => childTeam.id)
 
-    const keyResults = await this.keyResultService.getFromTeam(childTeamIds)
+    const teams = await this.getAllTeamsBelowNodes(teamId, ['id'])
+    const teamIDs = teams.map((team) => team.id)
+
+    const keyResults = await this.keyResultService.getFromTeam(teamIDs)
     if (!keyResults) return defaultConfidence
 
     const teamCurrentConfidence = this.keyResultService.getLowestConfidenceFromList(keyResults)


### PR DESCRIPTION
## ☕ Purpose

This PR fixes the current confidence of teams that were ignoring deep children.