### PR TITLE
Feature: Inactive users

### DIFF
--- a/src/core/modules/user/enums/user-status.enum.ts
+++ b/src/core/modules/user/enums/user-status.enum.ts
@@ -1,0 +1,4 @@
+export enum UserStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+}

--- a/src/core/modules/user/user.interface.ts
+++ b/src/core/modules/user/user.interface.ts
@@ -1,11 +1,13 @@
 import { CoreEntityInterface } from '@core/core-entity.interface'
 
 import { UserGender } from './enums/user-gender.enum'
+import { UserStatus } from './enums/user-status.enum'
 
 export interface UserInterface extends CoreEntityInterface {
   firstName: string
   authzSub: string
   email: string
+  status: UserStatus
   updatedAt: Date
   lastName?: string
   gender?: UserGender

--- a/src/core/modules/user/user.orm-entity.ts
+++ b/src/core/modules/user/user.orm-entity.ts
@@ -8,6 +8,7 @@ import { ObjectiveInterface } from '@core/modules/objective/interfaces/objective
 import { TeamInterface } from '@core/modules/team/interfaces/team.interface'
 
 import { UserGender } from './enums/user-gender.enum'
+import { UserStatus } from './enums/user-status.enum'
 import { UserInterface } from './user.interface'
 
 @Entity()
@@ -20,6 +21,9 @@ export class User extends CoreEntity implements UserInterface {
 
   @Column({ type: 'citext', unique: true })
   public email: string
+
+  @Column({ type: 'simple-enum', enum: UserStatus, default: UserStatus.ACTIVE })
+  public status: UserStatus
 
   @UpdateDateColumn()
   public updatedAt: Date

--- a/src/core/ports/commands/get-team-members.command.ts
+++ b/src/core/ports/commands/get-team-members.command.ts
@@ -3,6 +3,7 @@ import { Any } from 'typeorm'
 
 import { GetOptions } from '@core/interfaces/get-options'
 import { Team } from '@core/modules/team/team.orm-entity'
+import { UserStatus } from '@core/modules/user/enums/user-status.enum'
 import { UserInterface } from '@core/modules/user/user.interface'
 import { User } from '@core/modules/user/user.orm-entity'
 
@@ -37,6 +38,7 @@ export class GetTeamMembersCommand extends Command<User[]> {
     const selector = {
       ...filters,
       id: Any(userIDs),
+      status: UserStatus.ACTIVE,
     }
 
     return this.core.user.getMany(selector, undefined, options)

--- a/src/infrastructure/notification/channels/email/email.channel.ts
+++ b/src/infrastructure/notification/channels/email/email.channel.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 
 import { EmailAdapterProvider } from '@adapters/email/email.provider'
 import { EmailMetadata } from '@adapters/email/types/metadata.type'
+import { UserStatus } from '@core/modules/user/enums/user-status.enum'
 import { UserInterface } from '@core/modules/user/user.interface'
 import { AWSSESProvider } from '@infrastructure/aws/ses/ses.provider'
 import { EmailNotificationChannelMetadata } from '@infrastructure/notification/channels/email/metadata.type'
@@ -24,7 +25,9 @@ export class EmailNotificationChannel
     users: UserInterface[],
     usersCustomTemplateData?: Array<Record<string, any>>,
   ): NotificationRecipient[] {
-    return users.map((user, index) =>
+    const activeUsers = users.filter((user) => user.status === UserStatus.ACTIVE)
+
+    return activeUsers.map((user, index) =>
       EmailNotificationChannel.buildSingleRecipientFromUser(user, usersCustomTemplateData?.[index]),
     )
   }

--- a/src/infrastructure/orm/migrations/1631305358100-AddsUserStatus.ts
+++ b/src/infrastructure/orm/migrations/1631305358100-AddsUserStatus.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddsUserStatus1631305358100 implements MigrationInterface {
+  name = 'AddsUserStatus1631305358100'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TYPE "public"."user_status_enum" AS ENUM('ACTIVE', 'INACTIVE')`)
+    await queryRunner.query(
+      `ALTER TABLE "public"."user" ADD "status" "public"."user_status_enum" NOT NULL DEFAULT 'ACTIVE'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "public"."user" DROP COLUMN "status"`)
+    await queryRunner.query(`DROP TYPE "public"."user_status_enum"`)
+  }
+}

--- a/src/interface/graphql/modules/user/connections/users/users.resolver.ts
+++ b/src/interface/graphql/modules/user/connections/users/users.resolver.ts
@@ -4,6 +4,7 @@ import { Args } from '@nestjs/graphql'
 import { Resource } from '@adapters/policy/enums/resource.enum'
 import { UserWithContext } from '@adapters/state/interfaces/user.interface'
 import { CoreProvider } from '@core/core.provider'
+import { UserStatus } from '@core/modules/user/enums/user-status.enum'
 import { UserInterface } from '@core/modules/user/user.interface'
 import { User } from '@core/modules/user/user.orm-entity'
 import { GuardedQuery } from '@interface/graphql/adapters/authorization/decorators/guarded-query.decorator'
@@ -37,10 +38,15 @@ export class UsersConnectionGraphQLResolver extends GuardedConnectionGraphQLReso
       message: 'Fetching users with filters',
     })
 
-    const [filters, queryOptions, connection] = this.relay.unmarshalRequest<
+    const [rawFilters, queryOptions, connection] = this.relay.unmarshalRequest<
       UserFiltersRequest,
       User
     >(request)
+
+    const filters = {
+      ...rawFilters,
+      status: UserStatus.ACTIVE,
+    }
 
     const queryResult = await this.queryGuard.getManyWithActionScopeConstraint(
       filters,

--- a/src/interface/graphql/modules/user/enums/user-status.enum.ts
+++ b/src/interface/graphql/modules/user/enums/user-status.enum.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql/dist'
+
+import { UserStatus } from '@core/modules/user/enums/user-status.enum'
+
+export const UserStatusGraphQLEnum = UserStatus
+
+registerEnumType(UserStatusGraphQLEnum, {
+  name: 'UserStatus',
+  description: 'Each status represents a status for our users',
+})

--- a/src/interface/graphql/modules/user/user.node.ts
+++ b/src/interface/graphql/modules/user/user.node.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 
 import { UserGender } from '@core/modules/user/enums/user-gender.enum'
+import { UserStatus } from '@core/modules/user/enums/user-status.enum'
 import { GuardedNodeGraphQLInterface } from '@interface/graphql/adapters/authorization/interfaces/guarded-node.interface'
 import { NodePolicyGraphQLObject } from '@interface/graphql/adapters/authorization/objects/node-policy.object'
 import { NodeRelayGraphQLInterface } from '@interface/graphql/adapters/relay/interfaces/node.interface'
@@ -11,6 +12,7 @@ import { UserKeyResultsGraphQLConnection } from './connections/user-key-results/
 import { UserObjectivesGraphQLConnection } from './connections/user-objectives/user-objectives.connection'
 import { UserTeamsGraphQLConnection } from './connections/user-teams/user-teams.connection'
 import { UserGenderGraphQLEnum } from './enums/user-gender.enum'
+import { UserStatusGraphQLEnum } from './enums/user-status.enum'
 
 @ObjectType('User', {
   implements: () => [NodeRelayGraphQLInterface, GuardedNodeGraphQLInterface],
@@ -23,6 +25,9 @@ export class UserGraphQLNode implements GuardedNodeGraphQLInterface {
 
   @Field({ complexity: 0, description: 'The user e-mail' })
   public readonly email: string
+
+  @Field(() => UserStatusGraphQLEnum, { complexity: 0, description: 'The status of this user' })
+  public readonly status: UserStatus
 
   @Field({ complexity: 0, description: 'The sub field in Auth0 (their ID)' })
   public readonly authzSub!: string


### PR DESCRIPTION
## ☕ Purpose

This PR adds the structure to allow inactive users in our application. To do so, we've created the `STATUS` value objective, which defines if the user is `ACTIVE` or `INACTIVE`.

## 🧐 Checklist

- [x] Adds the status value objetive to our user entity;
- [x] Changes our user listing queries to ignore inactive users by default.
