### PR TITLE
bugfix(components/comment): allow char '-' as part of a name

### DIFF
--- a/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
+++ b/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
@@ -71,7 +71,7 @@ type CreatedKeyResultCommentMetadata = {
   supportTeam: UserInterface[]
 } & NotificationMetadata
 
-const mentionsRegex = /@\[(?<name>[\w \u00C0-\u00FF]+)]\((?<id>[\da-f-]+)\)/g
+const mentionsRegex = /@\[(?<name>[\w \u00C0-\u00FF-]+)]\((?<id>[\da-f-]+)\)/g
 @Injectable()
 export class CreatedKeyResultCommentNotification extends BaseNotification<
   CreatedKeyResultCommentNotificationData,


### PR DESCRIPTION
## ☕ Purpose

Fixes a bug then mentioning users in comments with `-` character.

## 🧐 Checklist
- [x] change mentionsRegex

## 🐞 Testing
I've checked both regex using [regexr](https://regexr.com/6ajht), with those strings:
```
@[Gilbert Caillet-Bois](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Gilbert Caillet Bois](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victor Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Víctor Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victõr Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victôr Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victòr Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victör Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
@[Victör-Perin](bdcb9199-ce5f-48b6-b50a-851e86795055)
```

#### Before
![image](https://user-images.githubusercontent.com/5847145/144110739-04420026-bec2-468d-936d-9cb603359b3c.png)

#### After
 ![image](https://user-images.githubusercontent.com/5847145/144110719-ddd0c390-4991-4ff7-9f08-8a1939edb873.png)


## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:
* https://github.com/budproj/execution-mode/pull/195
