### PR TITLE
Feat: auth subdomain stable

### DIFF
--- a/manifests/stable/deployment.yaml
+++ b/manifests/stable/deployment.yaml
@@ -46,9 +46,9 @@ spec:
                   name: business
                   key: typeorm-password
             - name: AUTHZ_ISSUER
-              value: https://getbud.us.auth0.com/
+              value: https://auth.getbud.co/
             - name: AUTHZ_DOMAIN
-              value: getbud.us.auth0.com
+              value: auth.getbud.co
             - name: AUTHZ_AUDIENCE
               value: https://api.getbud.co/business
             - name: AUTHZ_CLIENT_ID


### PR DESCRIPTION
## ☕ Purpose

This PR works together with auth0 new configuration to allow logins from domain `auth.getbud.co`.

## 🧐 Checklist

- [x] Change auth0 domain variable

## 🍩 Further details

- https://auth0.com/docs/brand-and-customize/custom-domains/auth0-managed-certificates

