### PR TITLE
Bug fix: using canary nats connection

### DIFF
--- a/manifests/canary/canary-deployment.yaml
+++ b/manifests/canary/canary-deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: ANALYTICS_PACKAGES
               value: keyResult
             - name: TASKS_NATS_SERVERS
-              value: nats.nats.svc.cluster.local:4222
+              value: nats-canary.nats.svc.cluster.local:4222
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## 🎢 Motivation

Canary and Production are using the same NATS server, they will receive messages in the same queues.

## 🔧 Solution

Change the connection and create a canary nats server

## 🚨  Testing

publish messages in canary without relying on production

## 🃏 Task Card

Link to issue on Jira

- NO JIRA ISSUE CREATED

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

### Discovered in:
- budproj/notifications-microservice#3

### Blocks:
- budproj/business#192

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
