### PR TITLE
feat(add-users-to-team) allow add a list of users at a team

### DIFF
--- a/src/interface/graphql/modules/user/connections/user-teams/requests/team-and-users.request.ts
+++ b/src/interface/graphql/modules/user/connections/user-teams/requests/team-and-users.request.ts
@@ -1,0 +1,14 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql'
+
+import { ConnectionFiltersRequest } from '@interface/graphql/requests/connection-filters.request'
+
+import { UserOrderInputObject } from '../../../objects/user-order-input.object'
+
+@ArgsType()
+export class TeamAndUsersRequest extends ConnectionFiltersRequest<UserOrderInputObject> {
+  @Field(() => [ID])
+  public readonly usersIDs: string[]
+
+  @Field(() => ID)
+  public readonly teamID: string
+}


### PR DESCRIPTION
## 🎢 Motivation

Allow a list of users to be added to a team.

## 🔧 Solution

A Mutation was created that goes through the list of users received, and for each user it invokes the already existing function of adding a single user to the team.

## 🚨  Testing

A possible Mutation:
```
mutation addTeamToUsers(
   $userIDs: [ID!]!
   $teamID: ID!
){
  addTeamToUsers(usersIDs: $userIDs, teamID: $teamID){
  	edges{
            node{
               firstName
       }
     }
   }
}

```
## 🃏 Task Card

Link to issue on Jira

- [`BUD22-419`](https://getbud.atlassian.net/browse/BUD22-419)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`execution-mode#300`](https://github.com/budproj/execution-mode/pull/300)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [x] Guilherme
- [ ] Rodrigo
- [ ] Diego
