### PR TITLE
feat(amplitude/track-teamleader) create isTeamLeader resolve field

### DIFF
--- a/src/interface/graphql/modules/user/user.access-control.ts
+++ b/src/interface/graphql/modules/user/user.access-control.ts
@@ -51,6 +51,14 @@ export class UserAccessControl extends AccessControl {
       })
   }
 
+  public async publicIsTeamLeader(user: UserWithContext): Promise<boolean> {
+    const { teams } = await this.getEntityRelatedEntities(user.id)
+
+    const isTeamLeader = await this.isTeamLeader(teams, user)
+
+    return isTeamLeader
+  }
+
   protected async resolveContextScopes(
     user: UserWithContext,
     teamID: string,

--- a/src/interface/graphql/modules/user/user.access-control.ts
+++ b/src/interface/graphql/modules/user/user.access-control.ts
@@ -51,7 +51,7 @@ export class UserAccessControl extends AccessControl {
       })
   }
 
-  public async publicIsTeamLeader(user: UserWithContext): Promise<boolean> {
+  public async isUserTeamLeader(user: UserWithContext): Promise<boolean> {
     const { teams } = await this.getEntityRelatedEntities(user.id)
 
     const isTeamLeader = await this.isTeamLeader(teams, user)

--- a/src/interface/graphql/modules/user/user.resolver.ts
+++ b/src/interface/graphql/modules/user/user.resolver.ts
@@ -342,6 +342,19 @@ export class UserGraphQLResolver extends GuardedNodeGraphQLResolver<User, UserIn
     return this.relay.marshalResponse<TeamInterface>(queryResult, connection, user)
   }
 
+  @ResolveField('isTeamLeader', () => Boolean, { nullable: true })
+  protected async getIsTeamLeaderForRequestAndUser(
+    @RequestUserWithContext() userWithContext: UserWithContext,
+  ) {
+    this.logger.log({
+      userWithContext,
+      message: 'Fetching if is team leader for user',
+    })
+    const isTeamLeader = await this.accessControl.publicIsTeamLeader(userWithContext)
+
+    return isTeamLeader
+  }
+
   @ResolveField('objectives', () => UserObjectivesGraphQLConnection, { nullable: true })
   protected async getObjectivesForRequestAndUser(
     @Args() request: ObjectiveFiltersRequest,

--- a/src/interface/graphql/modules/user/user.resolver.ts
+++ b/src/interface/graphql/modules/user/user.resolver.ts
@@ -350,7 +350,7 @@ export class UserGraphQLResolver extends GuardedNodeGraphQLResolver<User, UserIn
       userWithContext,
       message: 'Fetching if is team leader for user',
     })
-    const isTeamLeader = await this.accessControl.publicIsTeamLeader(userWithContext)
+    const isTeamLeader = await this.accessControl.isUserTeamLeader(userWithContext)
 
     return isTeamLeader
   }


### PR DESCRIPTION
## 🎢 Motivation

Getting to know if a user is a team leader in any team.

## 🔧 Solution

A resolve field was created that goes through all of a user's teams, checking if he is a team leader in at least one.

## 🚨  Testing

A possible query:
```
  me {
      isTeamLeader
  }

```
## 🃏 Task Card

Link to issue on Jira

- [`BUD22-421`](https://getbud.atlassian.net/jira/software/projects/BUD22/boards/16?assignee=622f47431c09d2007012fa64&selectedIssue=BUD22-421)

## 🔗 Related PRs

- [`execution-mode#304`](https://github.com/budproj/execution-mode/pull/304)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [x] Guilherme
- [ ] Rodrigo
- [ ] Diego
