### PR TITLE
fix(kr): individual kr email notification

### DIFF
--- a/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
+++ b/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
@@ -70,7 +70,7 @@ type CycleNotificationData = {
 type RelatedData = {
   keyResult: KeyResultInterface
   cycle: CycleInterface
-  team: TeamInterface
+  team?: TeamInterface
   owner: UserInterface
   supportTeam: UserInterface[]
 }
@@ -280,12 +280,20 @@ export class CreatedKeyResultCommentNotification extends BaseNotification<
     }
   }
 
-  private getTeamData(team: TeamInterface): TeamNotificationData {
-    return {
-      id: team.id,
-      name: team.name,
-      gender: team.gender,
+  private getTeamData(team?: TeamInterface): TeamNotificationData {
+    const fallbackTeamData = {
+      id: '',
+      name: '',
+      gender: TeamGender.NEUTRAL,
     }
+
+    return team
+      ? {
+          id: team.id,
+          name: team.name,
+          gender: team.gender,
+        }
+      : fallbackTeamData
   }
 
   private async getKeyResultData(
@@ -314,8 +322,10 @@ export class CreatedKeyResultCommentNotification extends BaseNotification<
     return this.core.dispatchCommand<CycleInterface>('get-key-result-cycle', keyResult)
   }
 
-  private async getTeam(keyResult: KeyResultInterface): Promise<TeamInterface> {
-    return this.core.dispatchCommand<TeamInterface>('get-key-result-team', keyResult)
+  private async getTeam(keyResult: KeyResultInterface): Promise<TeamInterface | undefined> {
+    if (keyResult.teamId) {
+      return this.core.dispatchCommand<TeamInterface>('get-key-result-team', keyResult)
+    }
   }
 
   private async dispatchMentions(): Promise<void> {


### PR DESCRIPTION
## 🎢 Motivation

Personal KRs were not sending notification when someone commented on them.

## 🔧 Solution

Return an empty fallback team if the KR has no teamId (is an individual one).

## 🚨  Testing

Comment on a company KR and on a personal one that isn't yours and both should receive a notification.

## 🍩 Validation

Who tested this PR?

### Canary

- [x] Marcelo
- [ ] Gustavo
- [x] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
