### PR TITLE
fix(kr): individual kr email notification

### DIFF
--- a/src/infrastructure/notification/notifications/created-key-result-check-mark.notification.ts
+++ b/src/infrastructure/notification/notifications/created-key-result-check-mark.notification.ts
@@ -78,7 +78,7 @@ type CycleNotificationData = {
 type RelatedData = {
   keyResult: KeyResultInterface
   cycle: CycleInterface
-  team: TeamInterface
+  team?: TeamInterface
   owner: UserInterface
   supportTeam: UserInterface[]
   assignedUser: UserInterface
@@ -264,11 +264,19 @@ export class CreatedKeyResultCheckMarkNotification extends BaseNotification<
   }
 
   private getTeamData(team: TeamInterface): TeamNotificationData {
-    return {
-      id: team.id,
-      name: team.name,
-      gender: team.gender,
+    const fallbackTeamData = {
+      id: '',
+      name: '',
+      gender: TeamGender.NEUTRAL,
     }
+
+    return team
+      ? {
+          id: team.id,
+          name: team.name,
+          gender: team.gender,
+        }
+      : fallbackTeamData
   }
 
   private async getKeyResultData(
@@ -298,7 +306,9 @@ export class CreatedKeyResultCheckMarkNotification extends BaseNotification<
   }
 
   private async getTeam(keyResult: KeyResultInterface): Promise<TeamInterface> {
-    return this.core.dispatchCommand<TeamInterface>('get-key-result-team', keyResult)
+    if (keyResult.teamId) {
+      return this.core.dispatchCommand<TeamInterface>('get-key-result-team', keyResult)
+    }
   }
 
   private async dispatchAssignedCheckMarkMessaging(): Promise<void> {

--- a/src/infrastructure/notification/notifications/created-key-result-check-mark.notification.ts
+++ b/src/infrastructure/notification/notifications/created-key-result-check-mark.notification.ts
@@ -143,8 +143,10 @@ export class CreatedKeyResultCheckMarkNotification extends BaseNotification<
   }
 
   public async dispatch(): Promise<void> {
-    await this.dispatchAssignedCheckMarkEmail()
-    await this.dispatchAssignedCheckMarkMessaging()
+    await Promise.allSettled([
+      this.dispatchAssignedCheckMarkEmail(),
+      this.dispatchAssignedCheckMarkMessaging(),
+    ])
   }
 
   private async dispatchAssignedCheckMarkEmail(): Promise<void> {

--- a/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
+++ b/src/infrastructure/notification/notifications/created-key-result-comment.notification.ts
@@ -129,7 +129,7 @@ export class CreatedKeyResultCommentNotification extends BaseNotification<
   }
 
   public async dispatch(): Promise<void> {
-    await Promise.all([this.dispatchOwnerAndSupportTeam(), this.dispatchMentions()])
+    await Promise.allSettled([this.dispatchOwnerAndSupportTeam(), this.dispatchMentions()])
   }
 
   getIdFromMentionedUsers(comment: string) {

--- a/src/infrastructure/notification/notifications/new-key-result-support-team-member.notification.ts
+++ b/src/infrastructure/notification/notifications/new-key-result-support-team-member.notification.ts
@@ -67,7 +67,7 @@ export class NewKeyResultSupportTeamMemberNotification extends BaseNotification<
   }
 
   public async dispatch(): Promise<void> {
-    await Promise.all([
+    await Promise.allSettled([
       this.dispatchSupportTeamMemberEmail(),
       this.dispatchSupportTeamMemberMessaging(),
     ])


### PR DESCRIPTION
## 🎢 Motivation

Personal KRs were not sending notifications when someone assigned a task for another.

## 🔧 Solution

Return an empty fallback team if the KR has no teamId (is an individual one).

## 🚨  Testing

Comment on a company KR and on a personal one that isn't yours and both should receive a notification.

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
