### PR TITLE
Feat/routine settings

### DIFF
--- a/src/core/modules/team/team.provider.ts
+++ b/src/core/modules/team/team.provider.ts
@@ -212,6 +212,15 @@ export class TeamProvider extends CoreEntityProvider<Team, TeamInterface> {
     return this.getTeamNodesTreeAfterTeam(companyIDs)
   }
 
+  public async getAllCompanies() {
+    return this.repository.find({
+      where: {
+        // eslint-disable-next-line unicorn/no-null
+        parentId: null,
+      },
+    })
+  }
+
   protected async protectCreationQuery(
     _query: CreationQuery<Team>,
     _data: Partial<TeamInterface>,

--- a/src/core/modules/team/team.provider.ts
+++ b/src/core/modules/team/team.provider.ts
@@ -186,7 +186,7 @@ export class TeamProvider extends CoreEntityProvider<Team, TeamInterface> {
   ): Promise<Team> {
     let rootTeam = await this.getOne({ id: team.id })
 
-    while (rootTeam.parentId) {
+    while (rootTeam.parentId && rootTeam.parentId !== rootTeam.id) {
       // Since we're dealing with a linked list, where we need to evaluate each step before trying
       // the next one, we can disable the following eslint rule
       // eslint-disable-next-line no-await-in-loop

--- a/src/core/ports/commands/command.factory.ts
+++ b/src/core/ports/commands/command.factory.ts
@@ -58,6 +58,7 @@ import { DeleteTaskCommand } from './delete-task.command'
 import { GetCheckListForKeyResultCommand } from './get-check-list-for-key-result.command'
 import { GetCheckListProgressCommand } from './get-check-list-progress.command'
 import { GetCheckListOfUserCommand } from './get-checklist-of-user'
+import { GetCompaniesCommand } from './get-companies.command'
 import { GetCycleCommand } from './get-cycle.command'
 import { GetKeyResultCheckInListCommand } from './get-key-result-check-in-list.command'
 import { GetKeyResultCheckInTeamCommand } from './get-key-result-check-in-team.command'
@@ -121,6 +122,7 @@ const commandTypes = [
   'get-check-list-for-key-result',
   'get-check-list-of-user',
   'get-check-list-progress',
+  'get-companies',
   'get-cycle',
   'get-cycle-delta',
   'get-cycle-status',
@@ -231,6 +233,7 @@ export class CommandFactory {
     'get-check-list-for-key-result': GetCheckListForKeyResultCommand,
     'get-check-list-of-user': GetCheckListOfUserCommand,
     'get-check-list-progress': GetCheckListProgressCommand,
+    'get-companies': GetCompaniesCommand,
     'get-cycle': GetCycleCommand,
     'get-cycle-delta': GetCycleDeltaCommand,
     'get-cycle-status': GetCycleStatusCommand,

--- a/src/core/ports/commands/get-companies.command.ts
+++ b/src/core/ports/commands/get-companies.command.ts
@@ -1,0 +1,10 @@
+import { Team } from '@core/modules/team/team.orm-entity'
+
+import { Command } from './base.command'
+
+export class GetCompaniesCommand extends Command<Team[]> {
+  public async execute(): Promise<Team[]> {
+    const companies = await this.core.team.getAllCompanies()
+    return companies
+  }
+}


### PR DESCRIPTION
## 🎢 Motivation

Allow admins to configure companies' routines

## 🔧 Solution

Create a route to save routine settings and schedule notifications

## 🚨  Testing

- Execute this micro-service
- Execute the scheduled micro-services
- Make a request for the /settings route
- Check if the settings were stored in the database
- Check if the notifications schedule was stored in the schedule database

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`routines-microservice#18`](https://github.com/budproj/routines-microservice/pull/18)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
