### PR TITLE
fix(getRooTeam): prevent circular dependency

### DIFF
--- a/src/core/modules/team/team.provider.ts
+++ b/src/core/modules/team/team.provider.ts
@@ -186,7 +186,7 @@ export class TeamProvider extends CoreEntityProvider<Team, TeamInterface> {
   ): Promise<Team> {
     let rootTeam = await this.getOne({ id: team.id })
 
-    while (rootTeam.parentId) {
+    while (rootTeam.parentId && rootTeam.parentId !== rootTeam.id) {
       // Since we're dealing with a linked list, where we need to evaluate each step before trying
       // the next one, we can disable the following eslint rule
       // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## 🎢 Motivation

Prevent infinity loop if the company tag itself as parent.

## 🔧 Solution

Exit loop if the parent id is the same id as the current company.

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
