### PR TITLE
Feat/notification

### DIFF
--- a/src/adapters/activity/activities/base.activity.ts
+++ b/src/adapters/activity/activities/base.activity.ts
@@ -27,8 +27,8 @@ export abstract class Activity<
 
   protected marshalMetadata(context: C): ActivityMetadata {
     return {
-      userID: context.userWithContext.id,
-      sessionID: context.tracing.sessionID,
+      userID: context.userWithContext?.id,
+      sessionID: context.tracing?.sessionID,
       timestamp: Date.now(),
     }
   }

--- a/src/adapters/activity/activities/generic-activity.ts
+++ b/src/adapters/activity/activities/generic-activity.ts
@@ -2,6 +2,8 @@ import { GraphQLRequest } from '@interface/graphql/adapters/context/interfaces/r
 
 import { Activity } from './base.activity'
 
+export const GenericTypes = 'PENDENCIES-NOTIFICATION'
+
 export class GenericActivity<D, R> extends Activity {
   constructor(
     public type: string,

--- a/src/adapters/activity/activities/generic-activity.ts
+++ b/src/adapters/activity/activities/generic-activity.ts
@@ -1,0 +1,14 @@
+import { GraphQLRequest } from '@interface/graphql/adapters/context/interfaces/request.interface'
+
+import { Activity } from './base.activity'
+
+export class GenericActivity<D, R> extends Activity {
+  constructor(
+    public type: string,
+    public readonly data: D,
+    public context: Partial<GraphQLRequest>,
+    public request: R,
+  ) {
+    super(data, context, request)
+  }
+}

--- a/src/core/modules/team/team.provider.ts
+++ b/src/core/modules/team/team.provider.ts
@@ -186,7 +186,7 @@ export class TeamProvider extends CoreEntityProvider<Team, TeamInterface> {
   ): Promise<Team> {
     let rootTeam = await this.getOne({ id: team.id })
 
-    while (rootTeam?.parentId !== rootTeam.id) {
+    while (rootTeam.parentId) {
       // Since we're dealing with a linked list, where we need to evaluate each step before trying
       // the next one, we can disable the following eslint rule
       // eslint-disable-next-line no-await-in-loop

--- a/src/core/ports/commands/check-if-user-has-pending-key-results.command.ts
+++ b/src/core/ports/commands/check-if-user-has-pending-key-results.command.ts
@@ -1,0 +1,26 @@
+import { Status } from '@core/interfaces/status.interface'
+import { KeyResult } from '@core/modules/key-result/key-result.orm-entity'
+import { User } from '@core/modules/user/user.orm-entity'
+
+import { Command } from './base.command'
+
+export class CheckIfUserHasPendingKeyResultCommand extends Command<number> {
+  public async execute(id: User['id']): Promise<number> {
+    const getUserKeyResults = this.factory.buildCommand<KeyResult[]>('get-user-key-results')
+    const getKeyResultStatus = this.factory.buildCommand<Status>('get-key-result-status')
+
+    const userKeyResults = await getUserKeyResults.execute(id, {})
+
+    const pendingKeyResults = await userKeyResults.reduce(async (promise, keyResult) => {
+      const previous = await promise
+
+      const { isOutdated } = await getKeyResultStatus.execute(keyResult.id)
+
+      if (isOutdated) return [...previous, keyResult]
+
+      return previous
+    }, Promise.resolve([]))
+
+    return pendingKeyResults.length
+  }
+}

--- a/src/core/ports/commands/command.factory.ts
+++ b/src/core/ports/commands/command.factory.ts
@@ -46,6 +46,7 @@ import { UpdateUserSettingCommand } from '@core/ports/commands/update-user-setti
 import { AddTeamToUserCommand } from './add-team-to-user.command'
 import { AddUserToKeyResultSupportTeamCommand } from './add-user-to-key-result-support-team.command'
 import { Command } from './base.command'
+import { CheckIfUserHasPendingKeyResultCommand } from './check-if-user-has-pending-key-results.command'
 import { CreateCheckMarkCommand } from './create-check-mark.command'
 import { CreateKeyResultCheckInCommand } from './create-key-result-check-in.command'
 import { CreateKeyResultCommentCommand } from './create-key-result-comment.command'
@@ -203,6 +204,7 @@ const commandTypes = [
   'request-change-user-password-email',
   'reactivate-user',
   'verify-token',
+  'check-if-user-has-pending-key-results',
 ] as const
 
 export type CommandType = typeof commandTypes[number]
@@ -312,6 +314,7 @@ export class CommandFactory {
     'request-change-user-password-email': RequestChangeUserPasswordEmailCommand,
     'reactivate-user': ReactivateUserCommand,
     'verify-token': VerifyToken,
+    'check-if-user-has-pending-key-results': CheckIfUserHasPendingKeyResultCommand,
   }
 
   constructor(private readonly core: CoreProvider) {}

--- a/src/core/ports/commands/get-team-members.command.ts
+++ b/src/core/ports/commands/get-team-members.command.ts
@@ -10,6 +10,7 @@ import { Command } from './base.command'
 
 export interface Filters extends Partial<UserInterface> {
   resolveTree?: boolean
+  withTeams?: boolean
 }
 
 export class GetTeamMembersCommand extends Command<User[]> {

--- a/src/core/ports/commands/get-team-members.command.ts
+++ b/src/core/ports/commands/get-team-members.command.ts
@@ -1,4 +1,4 @@
-import { flatten } from 'lodash'
+import { flatten, omit } from 'lodash'
 import { Any } from 'typeorm'
 
 import { GetOptions } from '@core/interfaces/get-options'
@@ -19,11 +19,12 @@ export class GetTeamMembersCommand extends Command<User[]> {
     { resolveTree, ...entityFilters }: Filters = {},
     options?: GetOptions<User>,
   ): Promise<User[]> {
+    const filteredEntiityFilters = omit(entityFilters, 'withTeams')
     const teams = resolveTree
       ? await this.core.team.getTeamNodesTreeAfterTeam(teamID)
       : [await this.core.team.getOne({ id: teamID })]
 
-    return this.getUsers(teams, entityFilters, options)
+    return this.getUsers(teams, filteredEntiityFilters, options)
   }
 
   private async getUsers(

--- a/src/core/ports/commands/get-users-from-team.command.ts
+++ b/src/core/ports/commands/get-users-from-team.command.ts
@@ -12,7 +12,18 @@ interface GetUsersFromTeamProperties {
 export class GetUsersFromTeam extends Command<User[]> {
   public async execute({ teamID, filters }: GetUsersFromTeamProperties): Promise<User[]> {
     const getTeamMembersCommand = this.factory.buildCommand<User[]>('get-team-members')
+    const getUserTeamTree = this.factory.buildCommand<Team[]>('get-user-team-tree')
 
-    return getTeamMembersCommand.execute(teamID, filters)
+    const users = await getTeamMembersCommand.execute(teamID, filters)
+
+    const usersWithTeams = await Promise.all(
+      users.map(async (user) => {
+        const teams = await getUserTeamTree.execute(user)
+
+        return { ...user, teams }
+      }),
+    )
+
+    return usersWithTeams
   }
 }

--- a/src/core/ports/commands/get-users-from-team.command.ts
+++ b/src/core/ports/commands/get-users-from-team.command.ts
@@ -16,14 +16,17 @@ export class GetUsersFromTeam extends Command<User[]> {
 
     const users = await getTeamMembersCommand.execute(teamID, filters)
 
-    const usersWithTeams = await Promise.all(
-      users.map(async (user) => {
-        const teams = await getUserTeamTree.execute(user)
+    if (filters.withTeams) {
+      const usersWithTeams = await Promise.all(
+        users.map(async (user) => {
+          const teams = await getUserTeamTree.execute(user)
 
-        return { ...user, teams }
-      }),
-    )
+          return { ...user, teams }
+        }),
+      )
+      return usersWithTeams
+    }
 
-    return usersWithTeams
+    return users
   }
 }

--- a/src/infrastructure/notification/notifications/notification.factory.ts
+++ b/src/infrastructure/notification/notifications/notification.factory.ts
@@ -16,6 +16,7 @@ import { Recipient } from '../types/recipient.type'
 import { CreatedKeyResultCheckInNotification } from './created-key-result-check-in.notification'
 import { CreatedKeyResultCheckMarkNotification } from './created-key-result-check-mark.notification'
 import { NewKeyResultSupportTeamMemberNotification } from './new-key-result-support-team-member.notification'
+import { PendingTasksNotification } from './pending-tasks.notification'
 
 export type Channels = EmailNotificationChannel | MessageBrokerNotificationChannel
 export type ChannelsMetadata = EmailNotificationChannelMetadata | MessageBrokerChannelMetadata
@@ -34,6 +35,7 @@ export class NotificationFactory {
     CreatedKeyResultCheckInNotification,
     NewKeyResultSupportTeamMemberNotification,
     CreatedKeyResultCheckMarkNotification,
+    PendingTasksNotification,
   ]
 
   private readonly channels: NotificationChannelHashMap

--- a/src/infrastructure/notification/notifications/pending-tasks.notification.ts
+++ b/src/infrastructure/notification/notifications/pending-tasks.notification.ts
@@ -100,7 +100,7 @@ export class PendingTasksNotification extends BaseNotification<
     const emailMetadata: EmailNotificationChannelMetadata = {
       ...metadata,
       recipients,
-      template: 'pendenciesReminder',
+      template: 'PendenciesReminder',
     }
 
     await this.channels.email.dispatch({}, emailMetadata)

--- a/src/infrastructure/notification/notifications/pending-tasks.notification.ts
+++ b/src/infrastructure/notification/notifications/pending-tasks.notification.ts
@@ -88,6 +88,7 @@ export class PendingTasksNotification extends BaseNotification<
     const { data, metadata } = this.marshal()
 
     const customData = data.map((user) => ({
+      userId: user.id,
       recipientFirstName: user.firstName,
     }))
 

--- a/src/infrastructure/notification/notifications/pending-tasks.notification.ts
+++ b/src/infrastructure/notification/notifications/pending-tasks.notification.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common'
+import { uniqBy } from 'lodash'
+
+import { GenericActivity, GenericTypes } from '@adapters/activity/activities/generic-activity'
+import { User } from '@core/modules/user/user.orm-entity'
+import { CorePortsProvider } from '@core/ports/ports.provider'
+
+import { EmailNotificationChannelMetadata } from '../channels/email/metadata.type'
+import { EmailRecipient } from '../types/email-recipient.type'
+import { NotificationMetadata } from '../types/notification-metadata.type'
+
+import { BaseNotification } from './base.notification'
+import { NotificationChannelHashMap } from './notification.factory'
+
+type Data = User[]
+
+type RelatedData = {
+  companyUsers: User[]
+  usersWithPendingRoutines: User[]
+}
+
+type Metadata = NotificationMetadata
+
+interface ActivityData {
+  companyUsers: User[]
+  usersWithPendingRoutines: User[]
+}
+
+@Injectable()
+export class PendingTasksNotification extends BaseNotification<
+  Data,
+  Metadata,
+  GenericActivity<ActivityData, never>
+> {
+  static activityType = GenericTypes
+  static notificationType = 'PendenciesNotification'
+
+  constructor(
+    activity: GenericActivity<ActivityData, never>,
+    channels: NotificationChannelHashMap,
+    core: CorePortsProvider,
+  ) {
+    super(activity, channels, core, PendingTasksNotification.notificationType)
+  }
+
+  public async prepare(): Promise<void> {
+    const relatedData = await this.getRelatedData()
+    const resolvedData = await this.getResolvedData(relatedData)
+
+    this.data = [...resolvedData]
+  }
+
+  public async dispatch(): Promise<void> {
+    await this.dispatchPendenciesReminderEmail()
+  }
+
+  private async getRelatedData(): Promise<RelatedData> {
+    const { companyUsers, usersWithPendingRoutines } = this.activity.data
+
+    return { companyUsers, usersWithPendingRoutines }
+  }
+
+  private async getResolvedData(relatedData: RelatedData): Promise<User[]> {
+    const usersWithPendingKeyResultsPromises = relatedData.companyUsers.map<
+      Promise<User | undefined>
+    >(async (user) => {
+      const pendingKeyResults = await this.core.dispatchCommand<number>(
+        'check-if-user-has-pending-key-results',
+        user.id,
+      )
+
+      if (pendingKeyResults > 0) return user
+    })
+
+    const usersWithPendingKeyResults = await Promise.all(usersWithPendingKeyResultsPromises)
+
+    const usersWithPendencies = [
+      ...usersWithPendingKeyResults.filter(Boolean),
+      ...relatedData.usersWithPendingRoutines,
+    ]
+
+    const uniqueArrayOfUsers = uniqBy<User>(usersWithPendencies, 'id')
+
+    return uniqueArrayOfUsers
+  }
+
+  private async dispatchPendenciesReminderEmail(): Promise<void> {
+    const { data, metadata } = this.marshal()
+
+    const customData = data.map((user) => ({
+      recipientFirstName: user.firstName,
+    }))
+
+    const recipients = (await this.buildRecipients(
+      data,
+      this.channels.email,
+      customData,
+    )) as EmailRecipient[]
+
+    const emailMetadata: EmailNotificationChannelMetadata = {
+      ...metadata,
+      recipients,
+      template: 'pendenciesReminder',
+    }
+
+    await this.channels.email.dispatch({}, emailMetadata)
+  }
+}

--- a/src/interface/tasks/tasks.controller.ts
+++ b/src/interface/tasks/tasks.controller.ts
@@ -28,14 +28,14 @@ export class TasksController {
     const context = {
       userWithContext: user,
     }
-    const a = new GenericActivity<unknown, unknown>(
+    const activity = new GenericActivity<unknown, unknown>(
       commandName,
       data,
       context as Partial<GraphQLRequest>,
       undefined,
     )
 
-    await this.notification.dispatch(a)
+    await this.notification.dispatch(activity)
   }
 
   @MessagePattern('core-ports.*')

--- a/src/interface/tasks/tasks.controller.ts
+++ b/src/interface/tasks/tasks.controller.ts
@@ -1,14 +1,37 @@
 import { Controller, Logger } from '@nestjs/common'
 import { Ctx, MessagePattern, NatsContext, Payload } from '@nestjs/microservices'
 
+import { GenericActivity } from '@adapters/activity/activities/generic-activity'
+import { NEW_KEY_RESULT_SUPPORT_TEAM_MEMBER_ACTIVITY_TYPE } from '@adapters/activity/activities/new-key-result-support-team-member.activity'
 import { isOfTypeCommand } from '@core/ports/commands/command.factory'
 import { CorePortsProvider } from '@core/ports/ports.provider'
+import { NotificationProvider } from '@infrastructure/notification/notification.provider'
 
 @Controller()
 export class TasksController {
   private readonly logger = new Logger(TasksController.name)
 
-  constructor(private readonly corePorts: CorePortsProvider) {}
+  constructor(
+    private readonly corePorts: CorePortsProvider,
+    private readonly notification: NotificationProvider,
+  ) {}
+
+  @MessagePattern('notify')
+  async teste() {
+    const a = new GenericActivity<unknown, { userId: string }>(
+      NEW_KEY_RESULT_SUPPORT_TEAM_MEMBER_ACTIVITY_TYPE,
+      {
+        id: 'a8b49219-7cc7-45f2-b435-004384689266',
+        metadata: {
+          userID: 'f120ec45-150d-4e24-b99d-34df20a80c64',
+        },
+      },
+      {},
+      { userId: 'f120ec45-150d-4e24-b99d-34df20a80c64' },
+    )
+
+    await this.notification.dispatch(a)
+  }
 
   @MessagePattern('core-ports.*')
   async useUsersPorts(@Payload() data: string, @Ctx() context: NatsContext): Promise<unknown> {

--- a/src/interface/tasks/tasks.controller.ts
+++ b/src/interface/tasks/tasks.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Logger } from '@nestjs/common'
 import { Ctx, MessagePattern, NatsContext, Payload } from '@nestjs/microservices'
+import { GraphQLRequest } from 'apollo-server-core'
 
 import { GenericActivity } from '@adapters/activity/activities/generic-activity'
-import { NEW_KEY_RESULT_SUPPORT_TEAM_MEMBER_ACTIVITY_TYPE } from '@adapters/activity/activities/new-key-result-support-team-member.activity'
+import { UserInterface } from '@core/modules/user/user.interface'
 import { isOfTypeCommand } from '@core/ports/commands/command.factory'
 import { CorePortsProvider } from '@core/ports/ports.provider'
 import { NotificationProvider } from '@infrastructure/notification/notification.provider'
@@ -16,18 +17,22 @@ export class TasksController {
     private readonly notification: NotificationProvider,
   ) {}
 
-  @MessagePattern('notify')
-  async teste() {
-    const a = new GenericActivity<unknown, { userId: string }>(
-      NEW_KEY_RESULT_SUPPORT_TEAM_MEMBER_ACTIVITY_TYPE,
-      {
-        id: 'a8b49219-7cc7-45f2-b435-004384689266',
-        metadata: {
-          userID: 'f120ec45-150d-4e24-b99d-34df20a80c64',
-        },
-      },
-      {},
-      { userId: 'f120ec45-150d-4e24-b99d-34df20a80c64' },
+  @MessagePattern('notification-ports.*')
+  async useNotification(@Payload() data: any, @Ctx() natsContext: NatsContext) {
+    const messageName = natsContext.getSubject()
+    const [_, commandName] = messageName.split('.')
+
+    const user = await this.corePorts.dispatchCommand<UserInterface>('get-user', {
+      id: data.userId,
+    })
+    const context = {
+      userWithContext: user,
+    }
+    const a = new GenericActivity<unknown, unknown>(
+      commandName,
+      data,
+      context as Partial<GraphQLRequest>,
+      undefined,
     )
 
     await this.notification.dispatch(a)

--- a/src/interface/tasks/tasks.module.ts
+++ b/src/interface/tasks/tasks.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 
 import { CoreModule } from '@core/core.module'
+import { NotificationModule } from '@infrastructure/notification/notification.module'
 import { TasksController } from '@interface/tasks/tasks.controller'
 
 @Module({
-  imports: [CoreModule],
+  imports: [CoreModule, NotificationModule],
   controllers: [TasksController],
   providers: [],
 })


### PR DESCRIPTION
## 🎢 Motivation

Creating a feature that sends an e-mail to the user at the end of the week, notifying his pendencies.
That means that the business needs to send the data via nats.

## 🔧 Solution

Creating a generic activty of the notification channel and a command to assist the routines microservice.
## 🚨  Testing

using command 'get-user-teams' and 'check-if-user-has-pending-key-result', using the generic activity of the routine notification

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-436`](https://getbud.atlassian.net/jira/software/projects/BUD22/boards/16?selectedIssue=BUD22-436/)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
