### PR TITLE
Bugfix: auth0 429 errors

### DIFF
--- a/src/config/authz/authz.config.ts
+++ b/src/config/authz/authz.config.ts
@@ -18,5 +18,16 @@ export const authzConfig = registerAs(
       default: process.env.AUTHZ_DOMAIN,
       mgmt: process.env.AUTHZ_MGMT_DOMAIN,
     },
+
+    scalability: {
+      tokenProvider: {
+        enableCache: true,
+        cacheTTLInSeconds: 10,
+      },
+      retry: {
+        enabled: true,
+        maxRetries: 10,
+      },
+    },
   }),
 )

--- a/src/config/authz/authz.interface.ts
+++ b/src/config/authz/authz.interface.ts
@@ -4,6 +4,7 @@ export interface AuthzConfigInterface {
   connection: string
   credentials: AuthzCredentialsInterface
   domains: AuthzDomainsInterface
+  scalability: AuthzScalabilityInterface
 }
 
 export interface AuthzCredentialsInterface {
@@ -14,4 +15,15 @@ export interface AuthzCredentialsInterface {
 export interface AuthzDomainsInterface {
   default: string
   mgmt: string
+}
+
+export interface AuthzScalabilityInterface {
+  tokenProvider: {
+    enableCache: boolean
+    cacheTTLInSeconds: number
+  }
+  retry: {
+    enabled: boolean
+    maxRetries: number
+  }
 }

--- a/src/config/authz/authz.provider.ts
+++ b/src/config/authz/authz.provider.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 
-import { AuthzCredentialsInterface, AuthzDomainsInterface } from './authz.interface'
+import {
+  AuthzCredentialsInterface,
+  AuthzDomainsInterface,
+  AuthzScalabilityInterface,
+} from './authz.interface'
 
 @Injectable()
 export class AuthzConfigProvider {
@@ -25,5 +29,9 @@ export class AuthzConfigProvider {
 
   get domains(): AuthzDomainsInterface {
     return this.configService.get<AuthzDomainsInterface>('authz.domains')
+  }
+
+  get scalability(): AuthzScalabilityInterface {
+    return this.configService.get<AuthzScalabilityInterface>('authz.scalability')
   }
 }

--- a/src/infrastructure/authz/providers/client.provider.ts
+++ b/src/infrastructure/authz/providers/client.provider.ts
@@ -22,6 +22,8 @@ export class AuthzClientProvider {
       domain: this.config.domains.mgmt,
       clientId: this.config.credentials.clientID,
       clientSecret: this.config.credentials.clientSecret,
+      tokenProvider: this.config.scalability.tokenProvider,
+      retry: this.config.scalability.retry,
     })
   }
 


### PR DESCRIPTION
## 🎢 Motivation

Our auth0 access is being rate limited.

## 🔧 Solution

This is a partial solution, but we can use some internal configs in auth0 management api to reduce our access to the API and, if we top the limit again, to automatic retry it.

## 🚨  Testing

Query users in graphql and add a field named `authzRole`. Each returned user will at least, resolve in one request to their API.

## 🃏 Task Card

We didn't create a card for this.

## 🔗 Related PRs

No relations, this is a standalone pull request.

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
