### PR TITLE
perf(commands): write some of our back logic into sql queries

### DIFF
--- a/src/core/core.provider.ts
+++ b/src/core/core.provider.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common'
+import { InjectEntityManager } from '@nestjs/typeorm'
+import { EntityManager } from 'typeorm'
 
 import { AuthJwtProvider } from '@infrastructure/authz/providers/jwt.provider'
 import { NatsProvider } from '@interface/nats/nats.provider'
@@ -13,6 +15,7 @@ import { UserProvider } from './modules/user/user.provider'
 @Injectable()
 export class CoreProvider {
   constructor(
+    @InjectEntityManager() public entityManager: EntityManager,
     public readonly user: UserProvider,
     public readonly team: TeamProvider,
     public readonly cycle: CycleProvider,

--- a/src/core/ports/commands/get-cycle-delta.command.ts
+++ b/src/core/ports/commands/get-cycle-delta.command.ts
@@ -15,70 +15,13 @@ export class GetCycleDeltaCommand extends BaseDeltaCommand {
   }
 
   public async execute(CycleID: string): Promise<Delta> {
-    const comparisonDate = this.getComparisonDate()
     const row = await this.core.entityManager.query(
       `
-      WITH latest_check_in_week_before AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        WHERE krci.created_at < $2
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-          key_result_status AS
-        (SELECT kr.id,
-                least(greatest(CASE
-                                  WHEN lci.value = kr.goal THEN 100
-                                  WHEN kr.goal = kr.initial_value THEN 0
-                                  ELSE 100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                              END, 0), 100) AS progress,
-                least(greatest(CASE
-                                  WHEN lciwb.value = kr.goal THEN 100
-                                  WHEN kr.goal = kr.initial_value THEN 0
-                                  ELSE 100 * (coalesce(lciwb.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                              END, 0), 100) AS previous_progress,
-                lci.confidence,
-                lciwb.confidence AS previous_confidence,
-                kr.objective_id,
-                kr.team_id
-        FROM public.key_result kr
-        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
-        LEFT JOIN latest_check_in_week_before lciwb ON kr.id = lciwb.key_result_id
-        JOIN public.objective o ON kr.objective_id = o.id
-        JOIN public.cycle c ON o.cycle_id = c.id),
-          objective_status AS
-        (SELECT krs.objective_id,
-                krs.team_id,
-                cy.id AS cycle_id,
-                cy.team_id AS company_id,
-                avg(progress) AS progress,
-                avg(previous_progress) AS previous_progress,
-                min(confidence) AS confidence,
-                min(previous_confidence) AS previous_confidence
-        FROM key_result_status krs
-        JOIN objective o ON krs.objective_id = o.id
-        JOIN CYCLE cy ON o.cycle_id = cy.id
-        WHERE o.mode = 'PUBLISHED'
-          AND cy.active IS TRUE
-        GROUP BY krs.objective_id,
-                  krs.team_id,
-                  cy.id,
-                  cy.team_id),
-          cycle_status AS
-        (SELECT o.cycle_id,
-                o.company_id,
-                greatest(avg(progress), 0) AS progress,
-                greatest(avg(previous_progress), 0) AS previous_progress,
-                min(confidence) AS confidence,
-                min(previous_confidence) AS previous_confidence
-        FROM objective_status o
-        WHERE o.team_id IS NOT NULL
-        GROUP BY o.cycle_id,
-                  o.company_id)
       SELECT *
       FROM cycle_status cs
       WHERE cs.cycle_id = $1
       `,
-      [CycleID, comparisonDate],
+      [CycleID],
     )
     if (row[0]) {
       return {

--- a/src/core/ports/commands/get-cycle-delta.command.ts
+++ b/src/core/ports/commands/get-cycle-delta.command.ts
@@ -18,78 +18,70 @@ export class GetCycleDeltaCommand extends BaseDeltaCommand {
     const comparisonDate = this.getComparisonDate()
     const row = await this.core.entityManager.query(
       `
-        with latest_check_in as (
-          select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-          order by krci.key_result_id, krci.created_at desc
-        ),
-        latest_check_in_week_before as (
-          select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-          where krci.created_at < $2
-          order by krci.key_result_id, krci.created_at desc
-        ),
-        key_result_status as (
-          select 
-            kr.id,
-            least(
-              greatest(
-                case 
-                  when lci.value = kr.goal then 100 
-                  when kr.goal = kr.initial_value then 0
-                else
-                  100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                end,
-              0),
-            100) as progress,	
-            least(
-              greatest(
-                case 
-                  when lciwb.value = kr.goal then 100 
-                  when kr.goal = kr.initial_value then 0
-                else
-                  100 * (coalesce(lciwb.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                end,
-              0),
-            100) as previous_progress,			
-            lci.confidence,
-            lciwb.confidence as previous_confidence,
-            kr.objective_id,
-            kr.team_id
-          from public.key_result kr 
-          left join latest_check_in lci on kr.id = lci.key_result_id
-          left join latest_check_in_week_before lciwb on kr.id = lciwb.key_result_id
-          join public.objective o on kr.objective_id  = o.id
-          join public.cycle c on o.cycle_id = c.id
-        ),
-        objective_status as (
-          select 
-            krs.objective_id,
-            krs.team_id,
-            cy.id as cycle_id,
-            cy.team_id as company_id,
-            avg(progress) as progress,
-            avg(previous_progress) as previous_progress,
-            min(confidence) as confidence,
-            min(previous_confidence) as previous_confidence
-          from key_result_status krs 
-          join objective o on krs.objective_id = o.id
-          join cycle cy on o.cycle_id = cy.id
-          where o.mode = 'PUBLISHED' and cy.active is true
-          group by krs.objective_id, krs.team_id, cy.id, cy.team_id
-        ),
-        cycle_status as (
-          select 
-            o.cycle_id,
-            o.company_id,
-            greatest(avg(progress), 0) as progress,
-            greatest(avg(previous_progress), 0) as previous_progress,
-            min(confidence) as confidence,
-            min(previous_confidence) as previous_confidence
-          from objective_status o
-          where o.team_id is not null
-          group by o.cycle_id, o.company_id
-        )
-        select * from cycle_status cs 
-          where cs.cycle_id = $1
+      WITH latest_check_in AS
+        (SELECT DISTINCT ON (krci.key_result_id) *
+        FROM public.key_result_check_in krci
+        ORDER BY krci.key_result_id,
+                  krci.created_at DESC),
+          latest_check_in_week_before AS
+        (SELECT DISTINCT ON (krci.key_result_id) *
+        FROM public.key_result_check_in krci
+        WHERE krci.created_at < $2
+        ORDER BY krci.key_result_id,
+                  krci.created_at DESC),
+          key_result_status AS
+        (SELECT kr.id,
+                least(greatest(CASE
+                                  WHEN lci.value = kr.goal THEN 100
+                                  WHEN kr.goal = kr.initial_value THEN 0
+                                  ELSE 100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
+                              END, 0), 100) AS progress,
+                least(greatest(CASE
+                                  WHEN lciwb.value = kr.goal THEN 100
+                                  WHEN kr.goal = kr.initial_value THEN 0
+                                  ELSE 100 * (coalesce(lciwb.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
+                              END, 0), 100) AS previous_progress,
+                lci.confidence,
+                lciwb.confidence AS previous_confidence,
+                kr.objective_id,
+                kr.team_id
+        FROM public.key_result kr
+        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN latest_check_in_week_before lciwb ON kr.id = lciwb.key_result_id
+        JOIN public.objective o ON kr.objective_id = o.id
+        JOIN public.cycle c ON o.cycle_id = c.id),
+          objective_status AS
+        (SELECT krs.objective_id,
+                krs.team_id,
+                cy.id AS cycle_id,
+                cy.team_id AS company_id,
+                avg(progress) AS progress,
+                avg(previous_progress) AS previous_progress,
+                min(confidence) AS confidence,
+                min(previous_confidence) AS previous_confidence
+        FROM key_result_status krs
+        JOIN objective o ON krs.objective_id = o.id
+        JOIN CYCLE cy ON o.cycle_id = cy.id
+        WHERE o.mode = 'PUBLISHED'
+          AND cy.active IS TRUE
+        GROUP BY krs.objective_id,
+                  krs.team_id,
+                  cy.id,
+                  cy.team_id),
+          cycle_status AS
+        (SELECT o.cycle_id,
+                o.company_id,
+                greatest(avg(progress), 0) AS progress,
+                greatest(avg(previous_progress), 0) AS previous_progress,
+                min(confidence) AS confidence,
+                min(previous_confidence) AS previous_confidence
+        FROM objective_status o
+        WHERE o.team_id IS NOT NULL
+        GROUP BY o.cycle_id,
+                  o.company_id)
+      SELECT *
+      FROM cycle_status cs
+      WHERE cs.cycle_id = $1
       `,
       [CycleID, comparisonDate],
     )

--- a/src/core/ports/commands/get-cycle-delta.command.ts
+++ b/src/core/ports/commands/get-cycle-delta.command.ts
@@ -18,12 +18,7 @@ export class GetCycleDeltaCommand extends BaseDeltaCommand {
     const comparisonDate = this.getComparisonDate()
     const row = await this.core.entityManager.query(
       `
-      WITH latest_check_in AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-          latest_check_in_week_before AS
+      WITH latest_check_in_week_before AS
         (SELECT DISTINCT ON (krci.key_result_id) *
         FROM public.key_result_check_in krci
         WHERE krci.created_at < $2
@@ -46,7 +41,7 @@ export class GetCycleDeltaCommand extends BaseDeltaCommand {
                 kr.objective_id,
                 kr.team_id
         FROM public.key_result kr
-        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
         LEFT JOIN latest_check_in_week_before lciwb ON kr.id = lciwb.key_result_id
         JOIN public.objective o ON kr.objective_id = o.id
         JOIN public.cycle c ON o.cycle_id = c.id),

--- a/src/core/ports/commands/get-cycle-delta.command.ts
+++ b/src/core/ports/commands/get-cycle-delta.command.ts
@@ -25,3 +25,81 @@ export class GetCycleDeltaCommand extends BaseDeltaCommand {
     return this.marshal(currentStatus, previousStatus)
   }
 }
+
+/*
+with latest_check_in as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      where krci.created_at < '2024-01-30'
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    latest_check_in_week_before as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      where krci.created_at < '2024-01-28'
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    key_result_status as (
+      select 
+        kr.id,
+        least(
+        	greatest(
+		        case 
+		          when lci.value = kr.goal then 100 
+		          when kr.goal = kr.initial_value then 0
+		        else
+        			100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+        		end,
+        	0),
+        100) as progress,	
+        least(
+        	greatest(
+		        case 
+		          when lciwb.value = kr.goal then 100 
+		          when kr.goal = kr.initial_value then 0
+		        else
+        			100 * (coalesce(lciwb.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+        		end,
+        	0),
+        100) as previous_progress,			
+        lci.confidence,
+        lciwb.confidence as previous_confidence,
+        kr.objective_id,
+        kr.team_id
+      from public.key_result kr 
+      left join latest_check_in lci on kr.id = lci.key_result_id
+      left join latest_check_in_week_before lciwb on kr.id = lciwb.key_result_id
+      join public.objective o on kr.objective_id  = o.id
+      join public.cycle c on o.cycle_id = c.id
+      -- where lci.confidence <> '-100'
+    ),
+    objective_status as (
+      select 
+        krs.objective_id,
+        krs.team_id,
+        cy.id as cycle_id,
+        cy.team_id as company_id,
+        avg(progress) as progress,
+        avg(previous_progress) as previous_progress,
+        min(confidence) as confidence,
+        min(previous_confidence) as previous_confidence
+      from key_result_status krs 
+      join objective o on krs.objective_id = o.id
+      join cycle cy on o.cycle_id = cy.id
+      where o.mode = 'PUBLISHED' and cy.active is true
+      group by krs.objective_id, krs.team_id, cy.id, cy.team_id
+    ),
+    cycle_status as (
+      select 
+        o.cycle_id,
+        o.company_id,
+        greatest(avg(progress), 0) as progress,
+        greatest(avg(previous_progress), 0) as previous_progress,
+        min(confidence) as confidence,
+        min(previous_confidence) as previous_confidence
+      from objective_status o
+      where o.team_id is not null
+      group by o.cycle_id, o.company_id
+    )
+    select * from cycle_status cs 
+--      where cs.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd'
+  		where cs.cycle_id = '74e34bec-79ce-454f-a752-3daec6be970b'
+*/

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -1,4 +1,5 @@
 import { GetStatusOptions, Status } from '@core/interfaces/status.interface'
+import { KeyResultCheckIn } from '@core/modules/key-result/check-in/key-result-check-in.orm-entity'
 import { BaseStatusCommand } from '@core/ports/commands/base-status.command'
 import { Stopwatch } from '@lib/logger/pino.decorator'
 
@@ -37,11 +38,25 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
       }
     }
 
+
+    const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
+    latest_check_in.id = row[0].latest_check_in?.id
+    latest_check_in.value = row[0].latest_check_in?.value
+    latest_check_in.confidence = row[0].latest_check_in?.confidence
+    latest_check_in.createdAt = new Date(row[0].latest_check_in?.created_at)
+    latest_check_in.keyResultId = row[0].latest_check_in?.key_result_id
+    latest_check_in.userId = row[0].latest_check_in?.user_id
+    latest_check_in.comment = row[0].latest_check_in?.comment
+    latest_check_in.parentId = row[0].latest_check_in?.parent_id
+    latest_check_in.previousState = row[0].latest_check_in?.previous_state
+
     return {
       isOutdated: row[0].is_outdated,
       isActive: row[0].is_active,
       progress: row[0].progress,
       confidence: row[0].confidence,
+      latestCheckIn: latest_check_in,
+      reportDate: new Date(row[0].last_check_in?.created_at),
     }
   }
 }

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -21,7 +21,7 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
                   krci.created_at DESC)
       SELECT cs.*,
             to_json(lcibc.*) AS latest_check_in
-      FROM cycle_current_status cs
+      FROM cycle_status cs
       JOIN latest_check_in_by_cycle lcibc ON cs.cycle_id = lcibc.cycle_id
       WHERE cs.cycle_id = $1
       `,

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -15,6 +15,85 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
     cycleID: string,
     options: GetStatusOptions = this.defaultOptions,
   ): Promise<Status> {
+    console.log('1. blah')
+    const row = await this.core.entityManager.query(
+      `
+      WITH latest_check_in AS
+        (SELECT DISTINCT ON (krci.key_result_id) *
+        FROM public.key_result_check_in krci
+        ORDER BY krci.key_result_id,
+                  krci.created_at DESC),
+          latest_check_in_by_cycle AS
+        (SELECT DISTINCT ON (o.cycle_id) *
+        FROM public.key_result_check_in krci
+        JOIN public.key_result kr ON krci.key_result_id = kr.id
+        JOIN public.objective o ON kr.objective_id = o.id
+        ORDER BY o.cycle_id,
+                  krci.created_at DESC),
+          key_result_status AS
+        (SELECT kr.id,
+                kr.title,
+                CASE
+                    WHEN lci.created_at < CURRENT_DATE - interval '6' DAY THEN TRUE
+                    ELSE FALSE
+                END AS is_outdated,
+                CASE
+                    WHEN lci.id IS NOT NULL THEN TRUE
+                    ELSE FALSE
+                END AS is_active,
+                c.active,
+                CASE
+                    WHEN lci.value = kr.goal THEN 100
+                    WHEN kr.goal = kr.initial_value THEN 0
+                    ELSE greatest(least(100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value), 100), 0)
+                END AS progress,
+                lci.confidence,
+                kr.objective_id,
+                kr.team_id,
+                c.id AS cycle_id
+        FROM public.key_result kr
+        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        JOIN public.objective o ON kr.objective_id = o.id
+        JOIN public.cycle c ON o.cycle_id = c.id
+        WHERE o.mode = 'PUBLISHED'
+          AND o.team_id IS NOT NULL ),
+          objective_status AS
+        (SELECT krs.objective_id,
+                krs.team_id,
+                cy.id AS cycle_id,
+                cy.team_id AS company_id,
+                bool_and(is_outdated) AS is_outdated,
+                bool_or(is_active) AS is_active,
+                least(greatest(avg(progress), 0), 100) AS progress,
+                min(confidence) AS confidence
+        FROM key_result_status krs
+        JOIN objective o ON krs.objective_id = o.id
+        JOIN CYCLE cy ON o.cycle_id = cy.id
+        WHERE o.mode = 'PUBLISHED'
+          AND cy.active IS TRUE
+        GROUP BY krs.objective_id,
+                  krs.team_id,
+                  cy.id,
+                  cy.team_id),
+          cycle_status AS
+        (SELECT o.cycle_id,
+                o.company_id,
+                bool_and(is_outdated) AS is_outdated,
+                bool_or(is_active) AS is_active,
+                least(greatest(avg(progress), 0), 100) AS progress,
+                min(confidence) AS confidence
+        FROM objective_status o
+        WHERE o.team_id IS NOT NULL
+        GROUP BY o.cycle_id,
+                  o.company_id)
+      SELECT cs.*,
+            to_json(lcibc.*) AS latestCheckIn
+      FROM cycle_status cs
+      JOIN latest_check_in_by_cycle lcibc ON cs.cycle_id = lcibc.cycle_id
+      WHERE cs.cycle_id = $1
+      `,
+      [cycleID],
+    )
     const keyResults = (await this.getKeyResultsFromCycle(cycleID, options)) as any
 
     const filteredKeyResults = keyResults.filter((keyResult) => keyResult.teamId !== null)
@@ -26,7 +105,25 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
     const latestCheckIn = this.getLatestCheckInFromList(cycleCheckIns)
     const isOutdated = this.isOutdated(latestCheckIn)
     const isActive = keyResults[0]?.objective?.cycle?.active ?? this.defaultStatus.isActive
-
+    console.log('2. blah')
+    console.log(row[0])
+    console.log({ // tá enroscado aqui
+      isOutdated: row[0].is_outdated,
+      isActive: row[0].is_active,
+      latestCheckIn: row[0].latestCheckIn,
+      reportDate: row[0].latestCheckIn.created_at,
+      progress: row[0].progress,
+      confidence: row[0].confidence,
+    })
+    console.log('3. O que eu fiz acima, o gabarito abaixo')
+    console.log({
+      isOutdated,
+      isActive,
+      latestCheckIn,
+      reportDate: latestCheckIn?.createdAt,
+      progress: this.getAverage(progresses),
+      confidence: this.getMin(confidences),
+    })
     return {
       isOutdated,
       isActive,
@@ -56,7 +153,7 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
       [['DESC']],
     )
 
-    /* with latest_check_in as (
+    /* With latest_check_in as (
       select distinct on (krci.key_result_id) * from public.key_result_check_in krci
       where krci.created_at < '2024-01-24'
       order by krci.key_result_id, krci.created_at desc
@@ -112,9 +209,9 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
     )
     select * from cycle_status cs 
       where cs.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd' */
-      
+
     const keyResults = await this.core.keyResult.getWithRelationFilters(filters, orderAttributes)
 
     return this.removeKeyResultCheckInsBeforeDate(keyResults, options.date)
-  } 
+  }
 }

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -21,7 +21,7 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
                   krci.created_at DESC)
       SELECT cs.*,
             to_json(lcibc.*) AS latest_check_in
-      FROM cycle_status cs
+      FROM cycle_current_status cs
       JOIN latest_check_in_by_cycle lcibc ON cs.cycle_id = lcibc.cycle_id
       WHERE cs.cycle_id = $1
       `,

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -56,8 +56,65 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
       [['DESC']],
     )
 
+    /* with latest_check_in as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      where krci.created_at < '2024-01-24'
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    key_result_status as (
+      select 
+        kr.id, 
+        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
+        c.active,
+        -- lci.*,
+        lci.created_at as last_check_in_date,
+        case 
+          when lci.value = kr.goal then 100 
+          when kr.goal = kr.initial_value then 0
+        else
+        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
+        lci.confidence,
+        kr.objective_id,
+        kr.team_id
+      from public.key_result kr 
+      left join latest_check_in lci on kr.id = lci.key_result_id
+      join public.objective o on kr.objective_id  = o.id
+      join public.cycle c on o.cycle_id = c.id
+      --where lci.confidence <> '-100'
+    ),
+    objective_status as (
+      select 
+        krs.objective_id,
+        krs.team_id,
+        cy.id as cycle_id,
+        cy.team_id as company_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        avg(progress) as progress,
+        min(confidence) as confidence
+      from key_result_status krs 
+      join objective o on krs.objective_id = o.id
+      join cycle cy on o.cycle_id = cy.id
+      where o.mode = 'PUBLISHED' and cy.active is true
+      group by krs.objective_id, krs.team_id, cy.id, cy.team_id
+    ),
+    cycle_status as (
+      select 
+        o.cycle_id,
+        o.company_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        greatest(avg(progress), 0) as progress,
+        min(confidence) as confidence
+      from objective_status o
+      where o.team_id is not null
+      group by o.cycle_id, o.company_id
+    )
+    select * from cycle_status cs 
+      where cs.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd' */
+      
     const keyResults = await this.core.keyResult.getWithRelationFilters(filters, orderAttributes)
 
     return this.removeKeyResultCheckInsBeforeDate(keyResults, options.date)
-  }
+  } 
 }

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -10,12 +10,7 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
   ): Promise<Status> {
     const row = await this.core.entityManager.query(
       `
-      WITH latest_check_in AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-      latest_check_in_by_cycle AS
+      WITH latest_check_in_by_cycle AS
         (SELECT DISTINCT ON (o.cycle_id) krci.*, o.cycle_id
         FROM public.key_result_check_in krci
         JOIN public.key_result kr ON krci.key_result_id = kr.id
@@ -46,7 +41,7 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
                 kr.team_id,
                 c.id AS cycle_id
         FROM public.key_result kr
-        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
         JOIN public.objective o ON kr.objective_id = o.id
         JOIN public.cycle c ON o.cycle_id = c.id
         WHERE o.mode = 'PUBLISHED'

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -18,66 +18,10 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
         WHERE o.mode = 'PUBLISHED'
           AND o.team_id IS NOT NULL 
         ORDER BY o.cycle_id,
-                  krci.created_at DESC),
-          key_result_status AS
-        (SELECT kr.id,
-                kr.title,
-                CASE
-                    WHEN lci.created_at < CURRENT_DATE - interval '6' DAY THEN TRUE
-                    ELSE FALSE
-                END AS is_outdated,
-                CASE
-                    WHEN lci.id IS NOT NULL THEN TRUE
-                    ELSE FALSE
-                END AS is_active,
-                c.active,
-                CASE
-                    WHEN lci.value = kr.goal THEN 100
-                    WHEN kr.goal = kr.initial_value THEN 0
-                    ELSE greatest(least(100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value), 100), 0)
-                END AS progress,
-                lci.confidence,
-                kr.objective_id,
-                kr.team_id,
-                c.id AS cycle_id
-        FROM public.key_result kr
-        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
-        JOIN public.objective o ON kr.objective_id = o.id
-        JOIN public.cycle c ON o.cycle_id = c.id
-        WHERE o.mode = 'PUBLISHED'
-          AND o.team_id IS NOT NULL ),
-          objective_status AS
-        (SELECT krs.objective_id,
-                krs.team_id,
-                cy.id AS cycle_id,
-                cy.team_id AS company_id,
-                bool_and(is_outdated) AS is_outdated,
-                bool_or(is_active) AS is_active,
-                least(greatest(avg(progress), 0), 100) AS progress,
-                min(confidence) AS confidence
-        FROM key_result_status krs
-        JOIN objective o ON krs.objective_id = o.id
-        JOIN CYCLE cy ON o.cycle_id = cy.id
-        WHERE o.mode = 'PUBLISHED'
-          AND cy.active IS TRUE
-        GROUP BY krs.objective_id,
-                  krs.team_id,
-                  cy.id,
-                  cy.team_id),
-          cycle_status AS
-        (SELECT o.cycle_id,
-                o.company_id,
-                bool_and(is_outdated) AS is_outdated,
-                bool_or(is_active) AS is_active,
-                least(greatest(avg(progress), 0), 100) AS progress,
-                min(confidence) AS confidence
-        FROM objective_status o
-        WHERE o.team_id IS NOT NULL
-        GROUP BY o.cycle_id,
-                  o.company_id)
+                  krci.created_at DESC)
       SELECT cs.*,
             to_json(lcibc.*) AS latest_check_in
-      FROM cycle_status cs
+      FROM cycle_current_status cs
       JOIN latest_check_in_by_cycle lcibc ON cs.cycle_id = lcibc.cycle_id
       WHERE cs.cycle_id = $1
       `,

--- a/src/core/ports/commands/get-cycle-status.command.ts
+++ b/src/core/ports/commands/get-cycle-status.command.ts
@@ -1,6 +1,5 @@
 import { GetStatusOptions, Status } from '@core/interfaces/status.interface'
-import { KeyResultMode } from '@core/modules/key-result/enums/key-result-mode.enum'
-import { KeyResult } from '@core/modules/key-result/key-result.orm-entity'
+import { KeyResultCheckIn } from '@core/modules/key-result/check-in/key-result-check-in.orm-entity'
 import { BaseStatusCommand } from '@core/ports/commands/base-status.command'
 import { Cacheable } from '@lib/cache/cacheable.decorator'
 import { Stopwatch } from '@lib/logger/pino.decorator'
@@ -15,7 +14,6 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
     cycleID: string,
     options: GetStatusOptions = this.defaultOptions,
   ): Promise<Status> {
-    console.log('1. blah')
     const row = await this.core.entityManager.query(
       `
       WITH latest_check_in AS
@@ -23,11 +21,13 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
         FROM public.key_result_check_in krci
         ORDER BY krci.key_result_id,
                   krci.created_at DESC),
-          latest_check_in_by_cycle AS
-        (SELECT DISTINCT ON (o.cycle_id) *
+      latest_check_in_by_cycle AS
+        (SELECT DISTINCT ON (o.cycle_id) krci.*, o.cycle_id
         FROM public.key_result_check_in krci
         JOIN public.key_result kr ON krci.key_result_id = kr.id
         JOIN public.objective o ON kr.objective_id = o.id
+        WHERE o.mode = 'PUBLISHED'
+          AND o.team_id IS NOT NULL 
         ORDER BY o.cycle_id,
                   krci.created_at DESC),
           key_result_status AS
@@ -87,131 +87,41 @@ export class GetCycleStatusCommand extends BaseStatusCommand {
         GROUP BY o.cycle_id,
                   o.company_id)
       SELECT cs.*,
-            to_json(lcibc.*) AS latestCheckIn
+            to_json(lcibc.*) AS latest_check_in
       FROM cycle_status cs
       JOIN latest_check_in_by_cycle lcibc ON cs.cycle_id = lcibc.cycle_id
       WHERE cs.cycle_id = $1
       `,
       [cycleID],
     )
-    const keyResults = (await this.getKeyResultsFromCycle(cycleID, options)) as any
 
-    const filteredKeyResults = keyResults.filter((keyResult) => keyResult.teamId !== null)
+    const latestCheckInNew = new KeyResultCheckIn()
+    latestCheckInNew.id = row[0].latest_check_in.id
+    latestCheckInNew.value = row[0].latest_check_in.value
+    latestCheckInNew.confidence = row[0].latest_check_in.confidence
+    latestCheckInNew.comment = row[0].latest_check_in.comment
+    latestCheckInNew.createdAt = row[0].latest_check_in.created_at
+    latestCheckInNew.keyResultId = row[0].latest_check_in.id
+    latestCheckInNew.userId = row[0].latest_check_in.id
+    latestCheckInNew.parentId = row[0].latest_check_in.parent_id
+    latestCheckInNew.previousState = row[0].latest_check_in.previous_state
 
-    const [cycleCheckIns, progresses, confidences] = await this.unzipKeyResultGroup(
-      filteredKeyResults,
-    )
-
-    const latestCheckIn = this.getLatestCheckInFromList(cycleCheckIns)
-    const isOutdated = this.isOutdated(latestCheckIn)
-    const isActive = keyResults[0]?.objective?.cycle?.active ?? this.defaultStatus.isActive
-    console.log('2. blah')
-    console.log(row[0])
-    console.log({ // tá enroscado aqui
+    console.log('1. blah blah2')
+    console.log({
       isOutdated: row[0].is_outdated,
       isActive: row[0].is_active,
-      latestCheckIn: row[0].latestCheckIn,
-      reportDate: row[0].latestCheckIn.created_at,
+      latestCheckIn: latestCheckInNew,
+      reportDate: row[0].latest_check_in.created_at,
       progress: row[0].progress,
       confidence: row[0].confidence,
     })
-    console.log('3. O que eu fiz acima, o gabarito abaixo')
-    console.log({
-      isOutdated,
-      isActive,
-      latestCheckIn,
-      reportDate: latestCheckIn?.createdAt,
-      progress: this.getAverage(progresses),
-      confidence: this.getMin(confidences),
-    })
     return {
-      isOutdated,
-      isActive,
-      latestCheckIn,
-      reportDate: latestCheckIn?.createdAt,
-      progress: this.getAverage(progresses),
-      confidence: this.getMin(confidences),
+      isOutdated: row[0].is_outdated,
+      isActive: row[0].is_active,
+      latestCheckIn: latestCheckInNew,
+      reportDate: row[0].latest_check_in.created_at,
+      progress: row[0].progress,
+      confidence: row[0].confidence,
     }
-  }
-
-  private async getKeyResultsFromCycle(
-    cycleID: string,
-    options: GetStatusOptions,
-  ): Promise<KeyResult[]> {
-    const filters = {
-      keyResult: {
-        createdAt: options.date,
-        mode: KeyResultMode.PUBLISHED,
-      },
-      cycle: {
-        id: cycleID,
-      },
-    }
-    const orderAttributes = this.zipEntityOrderAttributes(
-      ['keyResultCheckIn'],
-      [['createdAt']],
-      [['DESC']],
-    )
-
-    /* With latest_check_in as (
-      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-      where krci.created_at < '2024-01-24'
-      order by krci.key_result_id, krci.created_at desc
-    ),
-    key_result_status as (
-      select 
-        kr.id, 
-        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
-        c.active,
-        -- lci.*,
-        lci.created_at as last_check_in_date,
-        case 
-          when lci.value = kr.goal then 100 
-          when kr.goal = kr.initial_value then 0
-        else
-        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
-        lci.confidence,
-        kr.objective_id,
-        kr.team_id
-      from public.key_result kr 
-      left join latest_check_in lci on kr.id = lci.key_result_id
-      join public.objective o on kr.objective_id  = o.id
-      join public.cycle c on o.cycle_id = c.id
-      --where lci.confidence <> '-100'
-    ),
-    objective_status as (
-      select 
-        krs.objective_id,
-        krs.team_id,
-        cy.id as cycle_id,
-        cy.team_id as company_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        avg(progress) as progress,
-        min(confidence) as confidence
-      from key_result_status krs 
-      join objective o on krs.objective_id = o.id
-      join cycle cy on o.cycle_id = cy.id
-      where o.mode = 'PUBLISHED' and cy.active is true
-      group by krs.objective_id, krs.team_id, cy.id, cy.team_id
-    ),
-    cycle_status as (
-      select 
-        o.cycle_id,
-        o.company_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        greatest(avg(progress), 0) as progress,
-        min(confidence) as confidence
-      from objective_status o
-      where o.team_id is not null
-      group by o.cycle_id, o.company_id
-    )
-    select * from cycle_status cs 
-      where cs.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd' */
-
-    const keyResults = await this.core.keyResult.getWithRelationFilters(filters, orderAttributes)
-
-    return this.removeKeyResultCheckInsBeforeDate(keyResults, options.date)
   }
 }

--- a/src/core/ports/commands/get-objectives-and-key-results-quantities.command.ts
+++ b/src/core/ports/commands/get-objectives-and-key-results-quantities.command.ts
@@ -1,3 +1,4 @@
+import { KeyResultProvider } from '@core/modules/key-result/key-result.provider'
 import { TeamInterface } from '@core/modules/team/interfaces/team.interface'
 import { UserInterface } from '@core/modules/user/user.interface'
 

--- a/src/core/ports/commands/get-team-delta.command.ts
+++ b/src/core/ports/commands/get-team-delta.command.ts
@@ -27,3 +27,80 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
     return this.marshal(currentStatus, previousStatus)
   }
 }
+
+/*
+with latest_check_in as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      where krci.created_at < '2024-01-30'
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    latest_check_in_week_before as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      where krci.created_at < '2024-01-28'
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    key_result_status as (
+      select 
+        kr.id,
+        least(
+        	greatest(
+		        case 
+		          when lci.value = kr.goal then 100 
+		          when kr.goal = kr.initial_value then 0
+		        else
+        			100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+        		end,
+        	0),
+        100) as progress,	
+        least(
+        	greatest(
+		        case 
+		          when lciwb.value = kr.goal then 100 
+		          when kr.goal = kr.initial_value then 0
+		        else
+        			100 * (coalesce(lciwb.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+        		end,
+        	0),
+        100) as previous_progress,			
+        lci.confidence,
+        lciwb.confidence as previous_confidence,
+        kr.objective_id,
+        kr.team_id
+      from public.key_result kr 
+      left join latest_check_in lci on kr.id = lci.key_result_id
+      left join latest_check_in_week_before lciwb on kr.id = lciwb.key_result_id
+      join public.objective o on kr.objective_id  = o.id
+      join public.cycle c on o.cycle_id = c.id
+      -- where lci.confidence <> '-100'
+    ),
+    objective_status as (
+      select 
+        krs.objective_id,
+        krs.team_id,
+        cy.id as cycle_id,
+        cy.team_id as company_id,
+        avg(progress) as progress,
+        avg(previous_progress) as previous_progress,
+        min(confidence) as confidence,
+        min(previous_confidence) as previous_confidence
+      from key_result_status krs 
+      join objective o on krs.objective_id = o.id
+      join cycle cy on o.cycle_id = cy.id
+      where o.mode = 'PUBLISHED' and cy.active is true
+      group by krs.objective_id, krs.team_id, cy.id, cy.team_id
+    ),
+    team_status as (
+      select 
+        o.team_id,
+        o.company_id,
+        greatest(avg(progress), 0) as progress,
+        greatest(avg(previous_progress), 0) as previous_progress,
+        min(confidence) as confidence,
+        min(previous_confidence) as previous_confidence
+      from objective_status o
+      where o.team_id is not null
+      group by o.team_id, o.company_id
+    )
+    select * from team_status ts 
+      where ts.team_id = '0342b8f6-3a07-4f2b-a3fa-a3a8ca8fa61f'
+*/

--- a/src/core/ports/commands/get-team-delta.command.ts
+++ b/src/core/ports/commands/get-team-delta.command.ts
@@ -17,106 +17,93 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
 
   public async execute(teamID: string, options?: GetTeamStatusOptions): Promise<Delta> {
     const comparisonDate = this.getComparisonDate()
+    const row = await this.core.entityManager.query(
+      `
+      with latest_check_in as (
+        select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+        order by krci.key_result_id, krci.created_at desc
+      ),
+      latest_check_in_week_before as (
+        select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+        where krci.created_at < $2
+        order by krci.key_result_id, krci.created_at desc
+      ),
+      key_result_status as (
+        select 
+          kr.id,
+          least(
+            greatest(
+              case 
+                when lci.value = kr.goal then 100 
+                when kr.goal = kr.initial_value then 0
+              else
+                100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+              end,
+            0),
+          100) as progress,	
+          least(
+            greatest(
+              case 
+                when lciwb.value = kr.goal then 100 
+                when kr.goal = kr.initial_value then 0
+              else
+                100 * (coalesce(lciwb.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
+              end,
+            0),
+          100) as previous_progress,			
+          lci.confidence,
+          lciwb.confidence as previous_confidence,
+          kr.objective_id,
+          kr.team_id
+        from public.key_result kr 
+        left join latest_check_in lci on kr.id = lci.key_result_id
+        left join latest_check_in_week_before lciwb on kr.id = lciwb.key_result_id
+        join public.objective o on kr.objective_id  = o.id
+        join public.cycle c on o.cycle_id = c.id
+      ),
+      objective_status as (
+        select 
+          krs.objective_id,
+          krs.team_id,
+          cy.id as cycle_id,
+          cy.team_id as company_id,
+          avg(progress) as progress,
+          avg(previous_progress) as previous_progress,
+          min(confidence) as confidence,
+          min(previous_confidence) as previous_confidence
+        from key_result_status krs 
+        join objective o on krs.objective_id = o.id
+        join cycle cy on o.cycle_id = cy.id
+        where o.mode = 'PUBLISHED' and cy.active is true
+        group by krs.objective_id, krs.team_id, cy.id, cy.team_id
+      ),
+      team_status as (
+        select 
+          o.team_id,
+          o.company_id,
+          greatest(avg(progress), 0) as progress,
+          greatest(avg(previous_progress), 0) as previous_progress,
+          min(confidence) as confidence,
+          min(previous_confidence) as previous_confidence
+        from objective_status o
+        where o.team_id is not null
+        group by o.team_id, o.company_id
+      )
+      select * from team_status ts 
+        where ts.team_id = $1
+      `,
+      [teamID, comparisonDate],
+    )
+    if (row[0]) {
+      return {
+        progress: row[0].progress - row[0].previous_progress,
+        confidence: row[0].confidence - row[0].previous_confidence,
+      }
+    }
 
-    const currentStatus = await this.getTeamStatus.execute(teamID, options)
-    const previousStatus = await this.getTeamStatus.execute(teamID, {
-      ...options,
-      date: comparisonDate,
-    })
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log(this.marshal(currentStatus, previousStatus))
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    console.log('HEY BRO')
-    return this.marshal(currentStatus, previousStatus)
+    return {
+      progress: 0,
+      confidence: 0,
+    }
   }
 }
-
-/*
-with latest_check_in as (
-      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-      where krci.created_at < '2024-01-30'
-      order by krci.key_result_id, krci.created_at desc
-    ),
-    latest_check_in_week_before as (
-      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-      where krci.created_at < '2024-01-28'
-      order by krci.key_result_id, krci.created_at desc
-    ),
-    key_result_status as (
-      select 
-        kr.id,
-        least(
-        	greatest(
-		        case 
-		          when lci.value = kr.goal then 100 
-		          when kr.goal = kr.initial_value then 0
-		        else
-        			100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
-        		end,
-        	0),
-        100) as progress,	
-        least(
-        	greatest(
-		        case 
-		          when lciwb.value = kr.goal then 100 
-		          when kr.goal = kr.initial_value then 0
-		        else
-        			100 * (coalesce(lciwb.value,0) - kr.initial_value) / (kr.goal - kr.initial_value)
-        		end,
-        	0),
-        100) as previous_progress,			
-        lci.confidence,
-        lciwb.confidence as previous_confidence,
-        kr.objective_id,
-        kr.team_id
-      from public.key_result kr 
-      left join latest_check_in lci on kr.id = lci.key_result_id
-      left join latest_check_in_week_before lciwb on kr.id = lciwb.key_result_id
-      join public.objective o on kr.objective_id  = o.id
-      join public.cycle c on o.cycle_id = c.id
-      -- where lci.confidence <> '-100'
-    ),
-    objective_status as (
-      select 
-        krs.objective_id,
-        krs.team_id,
-        cy.id as cycle_id,
-        cy.team_id as company_id,
-        avg(progress) as progress,
-        avg(previous_progress) as previous_progress,
-        min(confidence) as confidence,
-        min(previous_confidence) as previous_confidence
-      from key_result_status krs 
-      join objective o on krs.objective_id = o.id
-      join cycle cy on o.cycle_id = cy.id
-      where o.mode = 'PUBLISHED' and cy.active is true
-      group by krs.objective_id, krs.team_id, cy.id, cy.team_id
-    ),
-    team_status as (
-      select 
-        o.team_id,
-        o.company_id,
-        greatest(avg(progress), 0) as progress,
-        greatest(avg(previous_progress), 0) as previous_progress,
-        min(confidence) as confidence,
-        min(previous_confidence) as previous_confidence
-      from objective_status o
-      where o.team_id is not null
-      group by o.team_id, o.company_id
-    )
-    select * from team_status ts 
-      where ts.team_id = '0342b8f6-3a07-4f2b-a3fa-a3a8ca8fa61f'
-*/

--- a/src/core/ports/commands/get-team-delta.command.ts
+++ b/src/core/ports/commands/get-team-delta.command.ts
@@ -16,71 +16,13 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
   }
 
   public async execute(teamID: string, options?: GetTeamStatusOptions): Promise<Delta> {
-    const comparisonDate = this.getComparisonDate()
     const row = await this.core.entityManager.query(
       `
-      WITH 
-          latest_check_in_week_before AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        WHERE krci.created_at < $2
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-          key_result_status AS
-        (SELECT kr.id,
-                least(greatest(CASE
-                                  WHEN lci.value = kr.goal THEN 100
-                                  WHEN kr.goal = kr.initial_value THEN 0
-                                  ELSE 100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                              END, 0), 100) AS progress,
-                least(greatest(CASE
-                                  WHEN lciwb.value = kr.goal THEN 100
-                                  WHEN kr.goal = kr.initial_value THEN 0
-                                  ELSE 100 * (coalesce(lciwb.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                              END, 0), 100) AS previous_progress,
-                lci.confidence,
-                lciwb.confidence AS previous_confidence,
-                kr.objective_id,
-                kr.team_id
-        FROM public.key_result kr
-        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
-        LEFT JOIN latest_check_in_week_before lciwb ON kr.id = lciwb.key_result_id
-        JOIN public.objective o ON kr.objective_id = o.id
-        JOIN public.cycle c ON o.cycle_id = c.id),
-          objective_status AS
-        (SELECT krs.objective_id,
-                krs.team_id,
-                cy.id AS cycle_id,
-                cy.team_id AS company_id,
-                avg(progress) AS progress,
-                avg(previous_progress) AS previous_progress,
-                min(confidence) AS confidence,
-                min(previous_confidence) AS previous_confidence
-        FROM key_result_status krs
-        JOIN objective o ON krs.objective_id = o.id
-        JOIN CYCLE cy ON o.cycle_id = cy.id
-        WHERE o.mode = 'PUBLISHED'
-          AND cy.active IS TRUE
-        GROUP BY krs.objective_id,
-                  krs.team_id,
-                  cy.id,
-                  cy.team_id),
-          team_status AS
-        (SELECT o.team_id,
-                o.company_id,
-                greatest(avg(progress), 0) AS progress,
-                greatest(avg(previous_progress), 0) AS previous_progress,
-                min(confidence) AS confidence,
-                min(previous_confidence) AS previous_confidence
-        FROM objective_status o
-        WHERE o.team_id IS NOT NULL
-        GROUP BY o.team_id,
-                  o.company_id)
       SELECT *
       FROM team_status ts
       WHERE ts.team_id = $1
       `,
-      [teamID, comparisonDate],
+      [teamID],
     )
     if (row[0]) {
       return {

--- a/src/core/ports/commands/get-team-delta.command.ts
+++ b/src/core/ports/commands/get-team-delta.command.ts
@@ -23,7 +23,23 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
       ...options,
       date: comparisonDate,
     })
-
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log(this.marshal(currentStatus, previousStatus))
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
+    console.log('HEY BRO')
     return this.marshal(currentStatus, previousStatus)
   }
 }

--- a/src/core/ports/commands/get-team-delta.command.ts
+++ b/src/core/ports/commands/get-team-delta.command.ts
@@ -19,11 +19,7 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
     const comparisonDate = this.getComparisonDate()
     const row = await this.core.entityManager.query(
       `
-      WITH latest_check_in AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
+      WITH 
           latest_check_in_week_before AS
         (SELECT DISTINCT ON (krci.key_result_id) *
         FROM public.key_result_check_in krci
@@ -47,7 +43,7 @@ export class GetTeamDeltaCommand extends BaseDeltaCommand {
                 kr.objective_id,
                 kr.team_id
         FROM public.key_result kr
-        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
         LEFT JOIN latest_check_in_week_before lciwb ON kr.id = lciwb.key_result_id
         JOIN public.objective o ON kr.objective_id = o.id
         JOIN public.cycle c ON o.cycle_id = c.id),

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -24,12 +24,7 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
   ): Promise<Team[]> {
     const rows = await this.core.entityManager.query(
       `
-      WITH latest_check_in AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-          key_result_status AS
+      WITH key_result_status AS
         (SELECT kr.id,
                 CASE
                     WHEN lci.created_at < CURRENT_DATE - interval '6' DAY THEN TRUE
@@ -46,7 +41,7 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
                 kr.objective_id,
                 kr.team_id
         FROM public.key_result kr
-        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
         JOIN public.objective o ON kr.objective_id = o.id
         JOIN public.cycle c ON o.cycle_id = c.id),
           objective_status AS

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -18,6 +18,19 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
 
     this.getTeamStatus = this.factory.buildCommand<Status>('get-team-status')
   }
+  // O objetivo é retornar o status dos descendentes de um time
+  // O que é o rankear? Estão ordenando pelo progresso do time
+  // Pelo que entendi, é uma query recursiva para fazer o ranking da primeira página
+  // Sendo que o Status englobal:
+  // progress: number
+  // confidence: number
+  // isOutdated: boolean
+  // isActive?: boolean
+  // reportDate?: Date
+  // latestCheckIn?: KeyResultCheckInInterface
+  // allUpToDateCheckIns?: KeyResultCheckInInterface[]
+  // checkmarks?: KeyResultCheckMarkInterface[]
+  // total?: number
 
   static rankTeamsByStatus(teams: Team[], status: Status[]): Team[] {
     const zippedTeams = zip(teams, status)
@@ -47,6 +60,64 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
       },
     }
     // TODO: use a single command to get all statuses at once
+    // select t.id, max(case when cy.active is true then 1 else 0 end) as is_active from dm_okr.dim__team t 
+    // join dm_okr.dim__cycle cy on t.company_id = cy.team_id
+    // group by t.id
+
+    /* with latest_check_in as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    key_result_status as (
+      select 
+        kr.id, 
+        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
+        c.active,
+        -- lci.*,
+        lci.created_at as last_check_in_date,
+        case 
+          when lci.value = kr.goal then 100 
+          when kr.goal = kr.initial_value then 0
+        else
+        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
+        lci.confidence,
+        kr.objective_id,
+        kr.team_id
+      from public.key_result kr 
+      left join latest_check_in lci on kr.id = lci.key_result_id
+      join public.objective o on kr.objective_id  = o.id
+      join public.cycle c on o.cycle_id = c.id
+      --where lci.confidence <> '-100'
+    ),
+    objective_status as (
+      select 
+        krs.objective_id,
+        krs.team_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        avg(progress) as progress,
+        min(confidence) as confidence
+      from key_result_status krs 
+      join objective o on krs.objective_id = o.id
+      join cycle cy on o.cycle_id = cy.id
+      where o.mode = 'PUBLISHED' and cy.active is true
+      group by krs.objective_id, krs.team_id
+    ),
+    team_status as (
+      select 
+        os.team_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        avg(progress) as progress,
+        min(confidence) as confidence
+      from objective_status os
+      group by os.team_id
+    )
+    select * from team_status ts 
+      join team_company tc on ts.team_id = tc.team_id
+      where tc.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd'
+    order by progress desc
+    */
     const teamStatusPromises = teams.map(async (team) =>
       this.getTeamStatus.execute(team.id, statusOptions),
     )

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -27,7 +27,7 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
       SELECT t.*
       FROM team t
       JOIN team_company tc ON t.id = tc.team_id
-      LEFT JOIN team_status ts ON ts.team_id = tc.team_id
+      LEFT JOIN team_current_status ts ON ts.team_id = tc.team_id
       WHERE t.parent_id IS NOT NULL AND tc.company_id = $1
       ORDER BY coalesce(progress, 0) DESC;
     `,

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -24,65 +24,62 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
   ): Promise<Team[]> {
     const rows = await this.core.entityManager.query(
       `
-      with latest_check_in as (
-        select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-        order by krci.key_result_id, krci.created_at desc
-      ),
-      key_result_status as (
-        select 
-          kr.id, 
-          case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
-          c.active,
-          lci.created_at as last_check_in_date,
-          case 
-            when lci.value = kr.goal then 100 
-            when kr.goal = kr.initial_value then 0
-          else
-          100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
-          lci.confidence,
-          kr.objective_id,
-          kr.team_id
-        from public.key_result kr 
-        left join latest_check_in lci on kr.id = lci.key_result_id
-        join public.objective o on kr.objective_id  = o.id
-        join public.cycle c on o.cycle_id = c.id
-      ),
-      objective_status as (
-        select 
-          krs.objective_id,
-          krs.team_id,
-          bool_or(is_outdated) as is_outdated,
-          max(last_check_in_date) as last_check_in_date,
-          avg(progress) as progress,
-          min(confidence) as confidence
-        from key_result_status krs 
-        join objective o on krs.objective_id = o.id
-        join cycle cy on o.cycle_id = cy.id
-        where o.mode = 'PUBLISHED' and cy.active is true
-        group by krs.objective_id, krs.team_id
-      ),
-      team_status as (
-        select 
-          os.team_id,
-          bool_or(is_outdated) as is_outdated,
-          max(last_check_in_date) as last_check_in_date,
-          avg(progress) as progress,
-          min(confidence) as confidence
-        from objective_status os
-        group by os.team_id
-      ),
-      team_descending_by_status as (
-        select ts.* from team_status ts 
-          join team_company tc on ts.team_id = tc.team_id
-          where tc.company_id = $1
-        order by progress desc
-    )
-    select 
-      t.* 
-    from
-      team t 
-      join team_descending_by_status tdbs 
-      on t.id = tdbs.team_id;
+      WITH latest_check_in AS
+        (SELECT DISTINCT ON (krci.key_result_id) *
+        FROM public.key_result_check_in krci
+        ORDER BY krci.key_result_id,
+                  krci.created_at DESC),
+          key_result_status AS
+        (SELECT kr.id,
+                CASE
+                    WHEN lci.created_at < CURRENT_DATE - interval '6' DAY THEN TRUE
+                    ELSE FALSE
+                END AS is_outdated,
+                c.active,
+                lci.created_at AS last_check_in_date,
+                CASE
+                    WHEN lci.value = kr.goal THEN 100
+                    WHEN kr.goal = kr.initial_value THEN 0
+                    ELSE 100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
+                END AS progress,
+                lci.confidence,
+                kr.objective_id,
+                kr.team_id
+        FROM public.key_result kr
+        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        JOIN public.objective o ON kr.objective_id = o.id
+        JOIN public.cycle c ON o.cycle_id = c.id),
+          objective_status AS
+        (SELECT krs.objective_id,
+                krs.team_id,
+                bool_or(is_outdated) AS is_outdated,
+                max(last_check_in_date) AS last_check_in_date,
+                avg(progress) AS progress,
+                min(confidence) AS confidence
+        FROM key_result_status krs
+        JOIN objective o ON krs.objective_id = o.id
+        JOIN CYCLE cy ON o.cycle_id = cy.id
+        WHERE o.mode = 'PUBLISHED'
+          AND cy.active IS TRUE
+        GROUP BY krs.objective_id,
+                  krs.team_id),
+          team_status AS
+        (SELECT os.team_id,
+                bool_or(is_outdated) AS is_outdated,
+                max(last_check_in_date) AS last_check_in_date,
+                avg(progress) AS progress,
+                min(confidence) AS confidence
+        FROM objective_status os
+        GROUP BY os.team_id),
+          team_descending_by_status AS
+        (SELECT ts.*
+        FROM team_status ts
+        JOIN team_company tc ON ts.team_id = tc.team_id
+        WHERE tc.company_id = $1
+        ORDER BY progress DESC)
+      SELECT t.*
+      FROM team t
+      JOIN team_descending_by_status tdbs ON t.id = tdbs.team_id;
     `,
       [teamID],
     )

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -27,7 +27,7 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
       SELECT t.*
       FROM team t
       JOIN team_company tc ON t.id = tc.team_id
-      LEFT JOIN team_current_status ts ON ts.team_id = tc.team_id
+      LEFT JOIN team_status ts ON ts.team_id = tc.team_id
       WHERE t.parent_id IS NOT NULL AND tc.company_id = $1
       ORDER BY coalesce(progress, 0) DESC;
     `,

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -1,4 +1,3 @@
-import { zip, unzip, sortBy, reverse } from 'lodash'
 import { FindConditions } from 'typeorm'
 
 import { CoreProvider } from '@core/core.provider'
@@ -8,7 +7,6 @@ import { TeamInterface } from '@core/modules/team/interfaces/team.interface'
 import { Team } from '@core/modules/team/team.orm-entity'
 import { Command } from '@core/ports/commands/base.command'
 import { CommandFactory } from '@core/ports/commands/command.factory'
-import { GetTeamStatusOptions } from '@core/ports/commands/get-team-status.command'
 
 export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
   private readonly getTeamStatus: Command<Status>
@@ -18,110 +16,88 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
 
     this.getTeamStatus = this.factory.buildCommand<Status>('get-team-status')
   }
-  // O objetivo é retornar o status dos descendentes de um time
-  // O que é o rankear? Estão ordenando pelo progresso do time
-  // Pelo que entendi, é uma query recursiva para fazer o ranking da primeira página
-  // Sendo que o Status englobal:
-  // progress: number
-  // confidence: number
-  // isOutdated: boolean
-  // isActive?: boolean
-  // reportDate?: Date
-  // latestCheckIn?: KeyResultCheckInInterface
-  // allUpToDateCheckIns?: KeyResultCheckInInterface[]
-  // checkmarks?: KeyResultCheckMarkInterface[]
-  // total?: number
-
-  static rankTeamsByStatus(teams: Team[], status: Status[]): Team[] {
-    const zippedTeams = zip(teams, status)
-    const ascendingSortedPairs = sortBy(zippedTeams, ([_, status]) => status.progress)
-    const descendingSortedPairs = reverse(ascendingSortedPairs)
-
-    const [sortedTeams] = unzip(descendingSortedPairs) as [Team[]]
-
-    return sortedTeams ?? []
-  }
 
   public async execute(
     teamID: string,
     filters?: FindConditions<TeamInterface>,
     queryOptions?: GetOptions<TeamInterface>,
   ): Promise<Team[]> {
-    const teamDescendants = await this.core.team.getDescendantsByIds([teamID], false, filters, queryOptions)
-    const teamDescendantsStatus = await this.getTeamsStatus(teamDescendants)
-
-    return GetTeamRankedDescendantsCommand.rankTeamsByStatus(teamDescendants, teamDescendantsStatus)
-  }
-
-  private async getTeamsStatus(teams: Team[]): Promise<Status[]> {
-    const statusOptions: GetTeamStatusOptions = {
-      cycleFilters: {
-        active: true,
-      },
-    }
-    // TODO: use a single command to get all statuses at once
-    // select t.id, max(case when cy.active is true then 1 else 0 end) as is_active from dm_okr.dim__team t 
-    // join dm_okr.dim__cycle cy on t.company_id = cy.team_id
-    // group by t.id
-
-    /* with latest_check_in as (
-      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-      order by krci.key_result_id, krci.created_at desc
-    ),
-    key_result_status as (
-      select 
-        kr.id, 
-        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
-        c.active,
-        -- lci.*,
-        lci.created_at as last_check_in_date,
-        case 
-          when lci.value = kr.goal then 100 
-          when kr.goal = kr.initial_value then 0
-        else
-        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
-        lci.confidence,
-        kr.objective_id,
-        kr.team_id
-      from public.key_result kr 
-      left join latest_check_in lci on kr.id = lci.key_result_id
-      join public.objective o on kr.objective_id  = o.id
-      join public.cycle c on o.cycle_id = c.id
-      --where lci.confidence <> '-100'
-    ),
-    objective_status as (
-      select 
-        krs.objective_id,
-        krs.team_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        avg(progress) as progress,
-        min(confidence) as confidence
-      from key_result_status krs 
-      join objective o on krs.objective_id = o.id
-      join cycle cy on o.cycle_id = cy.id
-      where o.mode = 'PUBLISHED' and cy.active is true
-      group by krs.objective_id, krs.team_id
-    ),
-    team_status as (
-      select 
-        os.team_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        avg(progress) as progress,
-        min(confidence) as confidence
-      from objective_status os
-      group by os.team_id
+    const rows = await this.core.entityManager.query(
+      `
+      with latest_check_in as (
+        select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+        order by krci.key_result_id, krci.created_at desc
+      ),
+      key_result_status as (
+        select 
+          kr.id, 
+          case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
+          c.active,
+          lci.created_at as last_check_in_date,
+          case 
+            when lci.value = kr.goal then 100 
+            when kr.goal = kr.initial_value then 0
+          else
+          100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
+          lci.confidence,
+          kr.objective_id,
+          kr.team_id
+        from public.key_result kr 
+        left join latest_check_in lci on kr.id = lci.key_result_id
+        join public.objective o on kr.objective_id  = o.id
+        join public.cycle c on o.cycle_id = c.id
+      ),
+      objective_status as (
+        select 
+          krs.objective_id,
+          krs.team_id,
+          bool_or(is_outdated) as is_outdated,
+          max(last_check_in_date) as last_check_in_date,
+          avg(progress) as progress,
+          min(confidence) as confidence
+        from key_result_status krs 
+        join objective o on krs.objective_id = o.id
+        join cycle cy on o.cycle_id = cy.id
+        where o.mode = 'PUBLISHED' and cy.active is true
+        group by krs.objective_id, krs.team_id
+      ),
+      team_status as (
+        select 
+          os.team_id,
+          bool_or(is_outdated) as is_outdated,
+          max(last_check_in_date) as last_check_in_date,
+          avg(progress) as progress,
+          min(confidence) as confidence
+        from objective_status os
+        group by os.team_id
+      ),
+      team_descending_by_status as (
+        select ts.* from team_status ts 
+          join team_company tc on ts.team_id = tc.team_id
+          where tc.company_id = $1
+        order by progress desc
     )
-    select * from team_status ts 
-      join team_company tc on ts.team_id = tc.team_id
-      where tc.company_id = 'f6790108-2b16-4077-bed0-103fc38175dd'
-    order by progress desc
-    */
-    const teamStatusPromises = teams.map(async (team) =>
-      this.getTeamStatus.execute(team.id, statusOptions),
+    select 
+      t.* 
+    from
+      team t 
+      join team_descending_by_status tdbs 
+      on t.id = tdbs.team_id;
+    `,
+      [teamID],
     )
 
-    return Promise.all(teamStatusPromises)
+    return rows.map((row) => {
+      const team = new Team()
+      team.name = row.name
+      team.updatedAt = row.updated_at
+      team.ownerId = row.owner_id
+      team.createdAt = row.created_at
+      team.id = row.id
+      team.description = row.description
+      team.gender = row.gender
+      team.parentId = row.parent_id
+      return team
+    })
   }
 }

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -24,57 +24,12 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
   ): Promise<Team[]> {
     const rows = await this.core.entityManager.query(
       `
-      WITH key_result_status AS
-        (SELECT kr.id,
-                CASE
-                    WHEN lci.created_at < CURRENT_DATE - interval '6' DAY THEN TRUE
-                    ELSE FALSE
-                END AS is_outdated,
-                c.active,
-                lci.created_at AS last_check_in_date,
-                CASE
-                    WHEN lci.value = kr.goal THEN 100
-                    WHEN kr.goal = kr.initial_value THEN 0
-                    ELSE 100 * (coalesce(lci.value, 0) - kr.initial_value) / (kr.goal - kr.initial_value)
-                END AS progress,
-                lci.confidence,
-                kr.objective_id,
-                kr.team_id
-        FROM public.key_result kr
-        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
-        JOIN public.objective o ON kr.objective_id = o.id
-        JOIN public.cycle c ON o.cycle_id = c.id),
-          objective_status AS
-        (SELECT krs.objective_id,
-                krs.team_id,
-                bool_or(is_outdated) AS is_outdated,
-                max(last_check_in_date) AS last_check_in_date,
-                avg(progress) AS progress,
-                min(confidence) AS confidence
-        FROM key_result_status krs
-        JOIN objective o ON krs.objective_id = o.id
-        JOIN CYCLE cy ON o.cycle_id = cy.id
-        WHERE o.mode = 'PUBLISHED'
-          AND cy.active IS TRUE
-        GROUP BY krs.objective_id,
-                  krs.team_id),
-          team_status AS
-        (SELECT os.team_id,
-                bool_or(is_outdated) AS is_outdated,
-                max(last_check_in_date) AS last_check_in_date,
-                avg(progress) AS progress,
-                min(confidence) AS confidence
-        FROM objective_status os
-        GROUP BY os.team_id),
-          team_descending_by_status AS
-        (SELECT ts.*
-        FROM team_status ts
-        JOIN team_company tc ON ts.team_id = tc.team_id
-        WHERE tc.company_id = $1
-        ORDER BY progress DESC)
       SELECT t.*
       FROM team t
-      JOIN team_descending_by_status tdbs ON t.id = tdbs.team_id;
+      JOIN team_company tc ON t.id = tc.team_id
+      LEFT JOIN team_current_status ts ON ts.team_id = tc.team_id
+      WHERE t.parent_id IS NOT NULL AND tc.company_id = $1
+      ORDER BY coalesce(progress, 0) DESC;
     `,
       [teamID],
     )

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -85,16 +85,16 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
     )
 
     return rows.map((row) => {
-      const team = new Team()
-      team.name = row.name
-      team.updatedAt = row.updated_at
-      team.ownerId = row.owner_id
-      team.createdAt = row.created_at
-      team.id = row.id
-      team.description = row.description
-      team.gender = row.gender
-      team.parentId = row.parent_id
-      return team
+      return Object.assign(new Team(), {
+        name: row.name,
+        updatedAt: row.updated_at,
+        ownerId: row.owner_id,
+        createdAt: row.created_at,
+        id: row.id,
+        description: row.description,
+        gender: row.gender,
+        parentId: row.parent_id,
+      })
     })
   }
 }

--- a/src/core/ports/commands/get-team-status.command.ts
+++ b/src/core/ports/commands/get-team-status.command.ts
@@ -22,12 +22,7 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
   ): Promise<Status> {
     const row = await this.core.entityManager.query(
       `
-      WITH latest_check_in AS
-        (SELECT DISTINCT ON (krci.key_result_id) *
-        FROM public.key_result_check_in krci
-        ORDER BY krci.key_result_id,
-                  krci.created_at DESC),
-          latest_check_in_by_team AS
+      WITH latest_check_in_by_team AS
         (SELECT DISTINCT ON (o.team_id) krci.*,
                             o.team_id
         FROM public.key_result_check_in krci
@@ -60,7 +55,7 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
                 kr.objective_id,
                 kr.team_id
         FROM public.key_result kr
-        LEFT JOIN latest_check_in lci ON kr.id = lci.key_result_id
+        LEFT JOIN key_result_latest_check_in lci ON kr.id = lci.key_result_id
         JOIN public.objective o ON kr.objective_id = o.id
         JOIN public.cycle c ON o.cycle_id = c.id),
           objective_status AS

--- a/src/core/ports/commands/get-team-status.command.ts
+++ b/src/core/ports/commands/get-team-status.command.ts
@@ -39,7 +39,58 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
       progress: this.getAverage(progresses),
       confidence: this.getMin(confidences),
     }
-  }
+    /* with latest_check_in as (
+      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+      order by krci.key_result_id, krci.created_at desc
+    ),
+    key_result_status as (
+      select 
+        kr.id, 
+        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
+        c.active,
+        -- lci.*,
+        lci.created_at as last_check_in_date,
+        case 
+          when lci.value = kr.goal then 100 
+          when kr.goal = kr.initial_value then 0
+        else
+        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
+        lci.confidence,
+        kr.objective_id,
+        kr.team_id
+      from public.key_result kr 
+      left join latest_check_in lci on kr.id = lci.key_result_id
+      join public.objective o on kr.objective_id  = o.id
+      join public.cycle c on o.cycle_id = c.id
+      --where lci.confidence <> '-100'
+    ),
+    objective_status as (
+      select 
+        krs.objective_id,
+        krs.team_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        avg(progress) as progress,
+        min(confidence) as confidence
+      from key_result_status krs 
+      join objective o on krs.objective_id = o.id
+      join cycle cy on o.cycle_id = cy.id
+      where o.mode = 'PUBLISHED' and cy.active is true
+      group by krs.objective_id, krs.team_id
+    ),
+    team_status as (
+      select 
+        os.team_id,
+        bool_or(is_outdated) as is_outdated,
+        max(last_check_in_date) as last_check_in_date,
+        avg(progress) as progress,
+        min(confidence) as confidence
+      from objective_status os
+      group by os.team_id
+    )
+    select * from team_status ts 
+      where ts.team_id = '3c239630-9167-431a-b502-b6fbecf5c09a' */
+  } 
 
   private async getKeyResultsFromTeam(
     teamID: string,

--- a/src/core/ports/commands/get-team-status.command.ts
+++ b/src/core/ports/commands/get-team-status.command.ts
@@ -1,5 +1,6 @@
 import { GetStatusOptions, Status } from '@core/interfaces/status.interface'
 import { CycleInterface } from '@core/modules/cycle/interfaces/cycle.interface'
+import { KeyResultCheckIn } from '@core/modules/key-result/check-in/key-result-check-in.orm-entity'
 import { KeyResultMode } from '@core/modules/key-result/enums/key-result-mode.enum'
 import { KeyResult } from '@core/modules/key-result/key-result.orm-entity'
 import { BaseStatusCommand } from '@core/ports/commands/base-status.command'
@@ -19,101 +20,99 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
     teamID: string,
     options: GetTeamStatusOptions = this.defaultOptions,
   ): Promise<Status> {
-    const anchorDate = new Date()
-    const rawKeyResults = await this.getKeyResultsFromTeam(teamID, options)
-    const keyResults = rawKeyResults.filter(
-      (keyResult) => keyResult.objective.cycle.dateStart < anchorDate,
+    const row = await this.core.entityManager.query(
+      `
+      with latest_check_in as (
+        select distinct on (krci.key_result_id) * from public.key_result_check_in krci
+        order by krci.key_result_id, krci.created_at desc
+      ),
+      latest_check_in_by_team AS
+        (SELECT DISTINCT ON (o.team_id) krci.*, o.team_id
+        FROM public.key_result_check_in krci
+        JOIN public.key_result kr ON krci.key_result_id = kr.id
+        JOIN public.objective o ON kr.objective_id = o.id
+        WHERE o.mode = 'PUBLISHED'
+          AND o.team_id IS NOT NULL 
+        ORDER BY o.team_id,
+                  krci.created_at DESC),
+      key_result_status as (
+        select 
+          kr.id, 
+          case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
+          case when lci.id is not null then true else false end as is_active,
+          c.active,
+          case 
+            when lci.value = kr.goal then 100 
+            when kr.goal = kr.initial_value then 0
+          else
+          100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
+          case when lci.confidence is null then 100 else lci.confidence end as confidence,
+          kr.objective_id,
+          kr.team_id
+        from public.key_result kr 
+        left join latest_check_in lci on kr.id = lci.key_result_id
+        join public.objective o on kr.objective_id  = o.id
+        join public.cycle c on o.cycle_id = c.id
+        --where lci.confidence <> '-100'
+      ),
+      objective_status as (
+        select 
+          krs.objective_id,
+          krs.team_id,
+          bool_and(is_outdated) as is_outdated,
+          bool_or(is_active) as is_active,
+          avg(progress) as progress,
+          min(confidence) as confidence
+        from key_result_status krs 
+        join objective o on krs.objective_id = o.id
+        join cycle cy on o.cycle_id = cy.id
+        where o.mode = 'PUBLISHED' and cy.active is true
+        group by krs.objective_id, krs.team_id
+      ),
+      team_status as (
+        select 
+          os.team_id,
+          bool_and(is_outdated) as is_outdated,
+          bool_or(is_active) as is_active,
+          avg(progress) as progress,
+          min(confidence) as confidence
+        from objective_status os
+        group by os.team_id
+      )
+      select ts.*, to_json(lcibt.*) as last_check_in from team_status ts join latest_check_in_by_team lcibt on ts.team_id = lcibt.team_id
+        where ts.team_id = $1
+      `,
+      [teamID],
     )
 
-    const [cycleCheckIns, progresses, confidences] = await this.unzipKeyResultGroup(keyResults)
-
-    const latestCheckIn = this.getLatestCheckInFromList(cycleCheckIns)
-    const isOutdated = this.isOutdated(latestCheckIn)
-    const isActive = GetTeamStatusCommand.isActive(keyResults)
-
-    return {
-      isOutdated,
-      isActive,
-      latestCheckIn,
-      reportDate: latestCheckIn?.createdAt,
-      progress: this.getAverage(progresses),
-      confidence: this.getMin(confidences),
+    if (Array.isArray(row) && row.length === 0) {
+      return {
+        isOutdated: true,
+        isActive: true,
+        progress: 0,
+        confidence: 100,
+      }
     }
-    /* with latest_check_in as (
-      select distinct on (krci.key_result_id) * from public.key_result_check_in krci
-      order by krci.key_result_id, krci.created_at desc
-    ),
-    key_result_status as (
-      select 
-        kr.id, 
-        case when lci.created_at < current_date - interval '6' day then true else false end as is_outdated,  
-        c.active,
-        -- lci.*,
-        lci.created_at as last_check_in_date,
-        case 
-          when lci.value = kr.goal then 100 
-          when kr.goal = kr.initial_value then 0
-        else
-        100 * (coalesce(lci.value,0) - kr.initial_value) / (kr.goal - kr.initial_value) end as progress,
-        lci.confidence,
-        kr.objective_id,
-        kr.team_id
-      from public.key_result kr 
-      left join latest_check_in lci on kr.id = lci.key_result_id
-      join public.objective o on kr.objective_id  = o.id
-      join public.cycle c on o.cycle_id = c.id
-      --where lci.confidence <> '-100'
-    ),
-    objective_status as (
-      select 
-        krs.objective_id,
-        krs.team_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        avg(progress) as progress,
-        min(confidence) as confidence
-      from key_result_status krs 
-      join objective o on krs.objective_id = o.id
-      join cycle cy on o.cycle_id = cy.id
-      where o.mode = 'PUBLISHED' and cy.active is true
-      group by krs.objective_id, krs.team_id
-    ),
-    team_status as (
-      select 
-        os.team_id,
-        bool_or(is_outdated) as is_outdated,
-        max(last_check_in_date) as last_check_in_date,
-        avg(progress) as progress,
-        min(confidence) as confidence
-      from objective_status os
-      group by os.team_id
-    )
-    select * from team_status ts 
-      where ts.team_id = '3c239630-9167-431a-b502-b6fbecf5c09a' */
-  } 
 
-  private async getKeyResultsFromTeam(
-    teamID: string,
-    options: GetTeamStatusOptions,
-  ): Promise<KeyResult[]> {
-    const filters = {
-      keyResult: {
-        createdAt: options.date,
-        mode: KeyResultMode.PUBLISHED,
-      },
-      team: {
-        id: teamID,
-      },
-      cycle: options.cycleFilters,
+    const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
+    latest_check_in.id = row[0].last_check_in?.id
+    latest_check_in.value = row[0].last_check_in?.value
+    latest_check_in.confidence = row[0].last_check_in?.confidence
+    latest_check_in.createdAt = new Date(row[0].last_check_in?.created_at)
+    latest_check_in.keyResultId = row[0].last_check_in?.key_result_id
+    latest_check_in.userId = row[0].last_check_in?.user_id
+    latest_check_in.comment = row[0].last_check_in?.comment
+    latest_check_in.parentId = row[0].last_check_in?.parent_id
+    latest_check_in.previousState = row[0].last_check_in?.previous_state
+
+    const toReturn: Status = {
+      isOutdated: row[0].is_outdated,
+      confidence: row[0].confidence,
+      progress: row[0].progress,
+      reportDate: new Date(row[0].last_check_in?.created_at),
+      isActive: row[0].is_active,
+      latestCheckIn: latest_check_in,
     }
-    const orderAttributes = this.zipEntityOrderAttributes(
-      ['keyResultCheckIn'],
-      [['createdAt']],
-      [['DESC']],
-    )
-
-    const keyResults = await this.core.keyResult.getWithRelationFilters(filters, orderAttributes)
-
-    return this.removeKeyResultCheckInsBeforeDate(keyResults, options.date)
+    return toReturn
   }
 }

--- a/src/core/ports/commands/get-team-status.command.ts
+++ b/src/core/ports/commands/get-team-status.command.ts
@@ -34,7 +34,7 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
                   krci.created_at DESC)
       SELECT ts.*,
             to_json(lcibt.*) AS last_check_in
-      FROM team_status ts
+      FROM team_current_status ts
       JOIN latest_check_in_by_team lcibt ON ts.team_id = lcibt.team_id
       WHERE ts.team_id = $1
       `,

--- a/src/core/ports/commands/get-team-status.command.ts
+++ b/src/core/ports/commands/get-team-status.command.ts
@@ -34,7 +34,7 @@ export class GetTeamStatusCommand extends BaseStatusCommand {
                   krci.created_at DESC)
       SELECT ts.*,
             to_json(lcibt.*) AS last_check_in
-      FROM team_current_status ts
+      FROM team_status ts
       JOIN latest_check_in_by_team lcibt ON ts.team_id = lcibt.team_id
       WHERE ts.team_id = $1
       `,

--- a/src/infrastructure/server/server.factory.ts
+++ b/src/infrastructure/server/server.factory.ts
@@ -32,7 +32,9 @@ export class ServerFactory {
   }
 
   private async createApplication(adapter: FastifyAdapter): Promise<NestFastifyApplication> {
-    const application = await NestFactory.create<NestFastifyApplication>(ServerModule, adapter)
+    const application = await NestFactory.create<NestFastifyApplication>(ServerModule, adapter, {
+      bufferLogs: true,
+    })
 
     application.enableCors()
 
@@ -45,6 +47,7 @@ export class ServerFactory {
 
     application.setGlobalPrefix(config.prefix ?? '')
     application.useLogger(logger)
+    application.flushLogs()
 
     await this.launchMicroservices(application, config)
     await this.launchServer(application, logger, config)

--- a/src/infrastructure/server/server.module.ts
+++ b/src/infrastructure/server/server.module.ts
@@ -5,6 +5,7 @@ import { LoggerModule } from 'nestjs-pino'
 import { ServerConfigModule } from '@config/server/server.module'
 import { InfrastructureModule } from '@infrastructure/infrastructure.module'
 import { InterfaceModule } from '@interface/interface.module'
+import { LogLevel } from '@lib/logger/logger.enum'
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { InterfaceModule } from '@interface/interface.module'
     InfrastructureModule,
     LoggerModule.forRoot({
       pinoHttp: {
+        level: LogLevel[process.env.SERVER_LOGGING_LEVEL],
         redact: {
           paths: ['req.headers'],
         },


### PR DESCRIPTION
## 🎢 Motivation

A brief summary of the purpose of this PR.

## 🔧 Solution

How the implementation works or fixes the issue.

## 🚨  Testing
Para testar, recomendo puxar o banco para o local, pois assim conseguimos comparar o que está em prod com o que está no local.

Para tal, seguem alguns comandos:
- Criar o dump do banco de prod no local:
`pg_dump -h <URL do banco de prod> -U airbyte -f <UM NOME QUALQUER>.sql  business`
- Subir os dados do dump para o local
`psql -U business -d business -h 0.0.0.0 -p 5432 -f <UM NOME QUALQUER>.sql `
- Alterar a autenticação do Morty (accounts+bud@getbud.co)
-- Entre no banco, pode ser via terminal ou DBeaver e execute:
`update "user" set authz_sub = 'auth0|5fd773cfd16a7c00694ae5ff' where email = 'igor.omote@getbud.co'`
-- Com isso, você irá me personificar, mesmo logando com o login do Morty
- Navegue por aí e compare com o que está em produção, majoritariamente são alterações em
-- Cálculo de progresso KRs por time e por ciclo
-- Evolução do progresso dos KRs por time e por ciclo

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-123`](https://)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
