### PR TITLE
perf(team_status): create new resolver to team_status

### DIFF
--- a/src/core/modules/user/user.interface.ts
+++ b/src/core/modules/user/user.interface.ts
@@ -16,6 +16,7 @@ export interface UserInterface extends CoreEntityInterface {
   nickname?: string
   about?: string
   linkedInProfileAddress?: string
+  fullName?: string
 }
 
 export interface UserCredentialsAdditionalData {

--- a/src/core/ports/commands/command.factory.ts
+++ b/src/core/ports/commands/command.factory.ts
@@ -35,6 +35,7 @@ import { GetUserFullNameCommand } from '@core/ports/commands/get-user-full-name.
 import { GetUserInitialsCommand } from '@core/ports/commands/get-user-initials.command'
 import { GetUserSettingsCommand } from '@core/ports/commands/get-user-settings.command'
 import { GetUserTeamTreeCommand } from '@core/ports/commands/get-user-team-tree.command'
+import { GetUserTeamsStatus } from '@core/ports/commands/get-user-teams-status'
 import { GetUserWithTeamsBySubCommand } from '@core/ports/commands/get-user-with-teams-from-sub.command'
 import { GetUserCommand } from '@core/ports/commands/get-user.command'
 import { InviteUserCommand } from '@core/ports/commands/invite-user.command'
@@ -180,6 +181,7 @@ const commandTypes = [
   'get-user-initials',
   'get-user-key-results',
   'get-user-settings',
+  'get-user-teams-status',
   'get-user-team-tree',
   'get-user-with-teams-by-sub',
   'get-users-by-ids',
@@ -300,6 +302,7 @@ export class CommandFactory {
     'get-user-initials': GetUserInitialsCommand,
     'get-user-key-results': GetUserKeyResultsCommand,
     'get-user-settings': GetUserSettingsCommand,
+    'get-user-teams-status': GetUserTeamsStatus,
     'get-user-team-tree': GetUserTeamTreeCommand,
     'get-user-with-teams-by-sub': GetUserWithTeamsBySubCommand,
     'get-users-by-ids': GetUsersByIdsCommand,

--- a/src/core/ports/commands/command.factory.ts
+++ b/src/core/ports/commands/command.factory.ts
@@ -33,9 +33,12 @@ import { GetTeamTreeCommand } from '@core/ports/commands/get-team-tree.command'
 import { GetTeamCommand } from '@core/ports/commands/get-team.command'
 import { GetUserFullNameCommand } from '@core/ports/commands/get-user-full-name.command'
 import { GetUserInitialsCommand } from '@core/ports/commands/get-user-initials.command'
+import { GetUserKeyResultsStatusesWithCheckMarksCommand } from '@core/ports/commands/get-user-key-results-statuses-with-checkmarks.command'
+import { GetUserKeyResultsStatusesCommand } from '@core/ports/commands/get-user-key-results-statuses.command'
 import { GetUserSettingsCommand } from '@core/ports/commands/get-user-settings.command'
 import { GetUserTeamTreeCommand } from '@core/ports/commands/get-user-team-tree.command'
 import { GetUserTeamsStatus } from '@core/ports/commands/get-user-teams-status'
+import { GetUserTeams } from '@core/ports/commands/get-user-teams.command'
 import { GetUserWithTeamsBySubCommand } from '@core/ports/commands/get-user-with-teams-from-sub.command'
 import { GetUserCommand } from '@core/ports/commands/get-user.command'
 import { InviteUserCommand } from '@core/ports/commands/invite-user.command'
@@ -182,6 +185,7 @@ const commandTypes = [
   'get-user-key-results',
   'get-user-settings',
   'get-user-teams-status',
+  'get-user-teams',
   'get-user-team-tree',
   'get-user-with-teams-by-sub',
   'get-users-by-ids',
@@ -221,6 +225,8 @@ const commandTypes = [
   'get-users-from-team',
   'get-team-flags',
   'get-user-key-results-status',
+  'get-user-key-results-statuses',
+  'get-user-key-results-statuses-with-checkmarks',
   'get-user-indicators',
   'get-user-profile-amplitude',
   'get-team-score',
@@ -301,8 +307,11 @@ export class CommandFactory {
     'get-user-full-name': GetUserFullNameCommand,
     'get-user-initials': GetUserInitialsCommand,
     'get-user-key-results': GetUserKeyResultsCommand,
+    'get-user-key-results-statuses': GetUserKeyResultsStatusesCommand,
+    'get-user-key-results-statuses-with-checkmarks': GetUserKeyResultsStatusesWithCheckMarksCommand,
     'get-user-settings': GetUserSettingsCommand,
     'get-user-teams-status': GetUserTeamsStatus,
+    'get-user-teams': GetUserTeams,
     'get-user-team-tree': GetUserTeamTreeCommand,
     'get-user-with-teams-by-sub': GetUserWithTeamsBySubCommand,
     'get-users-by-ids': GetUsersByIdsCommand,

--- a/src/core/ports/commands/get-team-ranked-descendants.ts
+++ b/src/core/ports/commands/get-team-ranked-descendants.ts
@@ -3,12 +3,14 @@ import { FindConditions } from 'typeorm'
 import { CoreProvider } from '@core/core.provider'
 import { GetOptions } from '@core/interfaces/get-options'
 import { Status } from '@core/interfaces/status.interface'
+import { KeyResultCheckIn } from '@core/modules/key-result/check-in/key-result-check-in.orm-entity'
 import { TeamInterface } from '@core/modules/team/interfaces/team.interface'
 import { Team } from '@core/modules/team/team.orm-entity'
 import { Command } from '@core/ports/commands/base.command'
 import { CommandFactory } from '@core/ports/commands/command.factory'
 
-export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
+// Alterar esse any para Team + latest Check in, mesma coisa no front
+export class GetTeamRankedDescendantsCommand extends Command<any[]> {
   private readonly getTeamStatus: Command<Status>
 
   constructor(protected core: CoreProvider, protected factory: CommandFactory) {
@@ -23,19 +25,72 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
     queryOptions?: GetOptions<TeamInterface>,
   ): Promise<Team[]> {
     const rows = await this.core.entityManager.query(
-      `
-      SELECT t.*
-      FROM team t
-      JOIN team_company tc ON t.id = tc.team_id
-      LEFT JOIN team_current_status ts ON ts.team_id = tc.team_id
-      WHERE t.parent_id IS NOT NULL AND tc.company_id = $1
-      ORDER BY coalesce(progress, 0) DESC;
+      `WITH latest_check_in_by_team AS
+      (SELECT DISTINCT ON (o.team_id) krci.*,
+                          o.team_id
+      FROM public.key_result_check_in krci
+      JOIN public.key_result kr ON krci.key_result_id = kr.id
+      JOIN public.objective o ON kr.objective_id = o.id
+      WHERE o.mode = 'PUBLISHED'
+        AND o.team_id IS NOT NULL
+      ORDER BY o.team_id,
+                krci.created_at DESC),
+    latest_check_in_by_team_with_user as (
+    select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as user from latest_check_in_by_team lci join "user" u on lci.user_id = u.id)
+    SELECT t.*,
+    to_json(ts.*) as status,
+    to_json(lcibt.*) as latest_check_in,
+    to_json(cqac.*) as "tacticalCycle",
+    ts.progress - ts.previous_progress as delta_progress,
+    ts.confidence - ts.previous_confidence as delta_confidence
+    FROM team t
+    JOIN team_company tc ON t.id = tc.team_id
+    join team_current_quarterly_active_cycle cqac on t.id = cqac.t_id
+    LEFT JOIN team_status ts ON ts.team_id = tc.team_id
+    join latest_check_in_by_team_with_user lcibt ON t.id = lcibt.team_id
+    WHERE t.parent_id IS NOT NULL AND tc.company_id = $1
+    ORDER BY coalesce(progress, 0) DESC;
     `,
       [teamID],
     )
 
     return rows.map((row) => {
-      return Object.assign(new Team(), {
+      const deltaData = {
+        progress: row.delta_progress ?? 0,
+        confidence: row.delta_confidence ?? 0,
+      }
+      const row_tactical_cycle = {
+        dateStart: new Date(row.tacticalCycle.date_start),
+        dateEnd: new Date(row.tacticalCycle.date_end),
+        createdAt: new Date(row.tacticalCycle.created_at),
+        updatedAt: new Date(row.tacticalCycle.updated_at),
+        id: row.tacticalCycle.id,
+        teamId: row.tacticalCycle.team_id,
+        period: row.tacticalCycle.period,
+        cadence: row.tacticalCycle.cadence,
+        active: row.tacticalCycle.active,
+        parentId: row.tacticalCycle.parent_id,
+      }
+      const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
+      latest_check_in.id = row.latest_check_in?.id
+      latest_check_in.value = row.latest_check_in?.value
+      latest_check_in.confidence = row.latest_check_in?.confidence
+      latest_check_in.createdAt = new Date(row.latest_check_in?.created_at)
+      latest_check_in.keyResultId = row.latest_check_in?.key_result_id
+      latest_check_in.userId = row.latest_check_in?.user_id
+      latest_check_in.comment = row.latest_check_in?.comment
+      latest_check_in.parentId = row.latest_check_in?.parent_id
+      latest_check_in.previousState = row.latest_check_in?.previous_state
+      latest_check_in.user = row.latest_check_in?.user
+      const row_status: Status = {
+        progress: row?.status?.progress ?? 0,
+        confidence: row?.status?.confidence ?? 0,
+        isOutdated: row.is_outdated,
+        reportDate: new Date(row.latest_check_in?.created_at),
+        isActive: row.is_active,
+        latestCheckIn: latest_check_in,
+      }
+      return {
         name: row.name,
         updatedAt: row.updated_at,
         ownerId: row.owner_id,
@@ -44,7 +99,10 @@ export class GetTeamRankedDescendantsCommand extends Command<Team[]> {
         description: row.description,
         gender: row.gender,
         parentId: row.parent_id,
-      })
+        statuses: row_status,
+        deltas: deltaData,
+        tacticalCycles: row_tactical_cycle,
+      }
     })
   }
 }

--- a/src/core/ports/commands/get-user-key-results-statuses-with-checkmarks.command.ts
+++ b/src/core/ports/commands/get-user-key-results-statuses-with-checkmarks.command.ts
@@ -1,0 +1,39 @@
+import { KeyResultInterface } from '@core/modules/key-result/interfaces/key-result.interface'
+import { KeyResult } from '@core/modules/key-result/key-result.orm-entity'
+
+import { Command } from './base.command'
+
+type Options = {
+  active?: boolean
+  onlyOwnerKeyResults?: boolean
+}
+
+// Ainda não foi propriamnete testada, não achei onde é chamada
+export class GetUserKeyResultsStatusesWithCheckMarksCommand extends Command<KeyResult[]> {
+  public async execute(
+    userID: string,
+    filters?: KeyResultInterface,
+    options?: Options,
+  ): Promise<KeyResult[]> {
+    const keyResults = await this.core.entityManager.query(
+      `
+      WITH latest_check_in_by_kr AS
+            (SELECT DISTINCT ON (kr.id) krci.*
+            FROM public.key_result_check_in krci
+            JOIN public.key_result kr ON krci.key_result_id = kr.id
+            ORDER BY kr.id,
+                      krci.created_at DESC),
+         latest_check_in_by_kr_with_user as (
+          select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as user from latest_check_in_by_kr lci join "user" u on lci.user_id = u.id)
+          
+          select kr.*, to_json(krs.*) as status, to_json(lci.*) as latest_check_infrom key_result_check_mark krcm 
+      join key_result kr on krcm.key_result_id = kr.id
+      join key_result_status krs on kr.id = krs.id
+      left join latest_check_in_by_kr_with_user lci on kr.id = lci.key_result_id
+      where krcm.assigned_user_id = $1 
+      and kr.mode = $2`,
+      [userID, filters.mode],
+    )
+    return keyResults
+  }
+}

--- a/src/core/ports/commands/get-user-key-results-statuses.command.ts
+++ b/src/core/ports/commands/get-user-key-results-statuses.command.ts
@@ -1,0 +1,118 @@
+import { uniqBy } from 'lodash'
+
+import { Status } from '@core/interfaces/status.interface'
+// eslint-disable-next-line import/order
+import { KeyResultCheckIn } from '@core/modules/key-result/check-in/key-result-check-in.orm-entity'
+
+// Export interface Status {
+//     progress: number
+//     confidence: number
+//     isOutdated: boolean
+//     latestCheckIn?: KeyResultCheckInInterface
+//     checkmarks?: KeyResultCheckMarkInterface[]
+//   }
+
+import { KeyResultInterface } from '@core/modules/key-result/interfaces/key-result.interface'
+import { KeyResult } from '@core/modules/key-result/key-result.orm-entity'
+
+import { Command } from './base.command'
+
+type Options = {
+  active?: boolean
+  onlyOwnerKeyResults?: boolean
+}
+
+export class GetUserKeyResultsStatusesCommand extends Command<any[]> {
+  public async execute(
+    userID: string,
+    filters?: KeyResultInterface,
+    options?: Options,
+  ): Promise<KeyResult[]> {
+    const rowsOwnerKeyResults = await this.core.entityManager.query(
+      `
+      WITH latest_check_in_by_kr AS
+            (SELECT DISTINCT ON (kr.id) krci.*
+            FROM public.key_result_check_in krci
+            JOIN public.key_result kr ON krci.key_result_id = kr.id
+            ORDER BY kr.id,
+                      krci.created_at DESC),
+         latest_check_in_by_kr_with_user as (
+          select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as user from latest_check_in_by_kr lci join "user" u on lci.user_id = u.id)
+          
+          select kr.*, to_json(krs.*) as status, to_json(lci.*) as latest_check_in from key_result kr 
+      join key_result_status krs on kr.id = krs.id
+      left join latest_check_in_by_kr_with_user lci on kr.id = lci.key_result_id
+      where kr.owner_id = $1 
+      and mode = $2`,
+      [userID, filters.mode],
+    )
+    const rowsSupportTeamKeyResults = await this.core.entityManager.query(
+      `WITH latest_check_in_by_kr AS
+    (SELECT DISTINCT ON (kr.id) krci.*
+    FROM public.key_result_check_in krci
+    JOIN public.key_result kr ON krci.key_result_id = kr.id
+    ORDER BY kr.id,
+              krci.created_at DESC),
+    latest_check_in_by_kr_with_user as (
+    select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as user from latest_check_in_by_kr lci join "user" u on lci.user_id = u.id)
+    
+    select kr.*, to_json(krs.*) as status, to_json(lci.*) as latest_check_in from key_result kr 
+    join key_result_support_team_members_user krstmu on kr.id = krstmu.key_result_id 
+    join key_result_status krs on kr.id = krs.id
+    left join latest_check_in_by_kr_with_user lci on kr.id = lci.key_result_id
+    where krstmu.user_id = $1 and mode = $2
+`,
+      [userID, filters.mode],
+    )
+    const allKeyResult = uniqBy([...rowsOwnerKeyResults, ...rowsSupportTeamKeyResults], 'id')
+    if (options?.onlyOwnerKeyResults) {
+      // Falta aplicar options, const keyResults = await this.applyOptions(ownedKeyResults, options)
+      return rowsOwnerKeyResults
+    }
+
+    // Falta aplicar options aparentemente é só active, const keyResults = await this.applyOptions(allKeyResults, options)
+
+    return allKeyResult.map((row) => {
+      const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
+      latest_check_in.id = row.latest_check_in?.id
+      latest_check_in.value = row.latest_check_in?.value
+      latest_check_in.confidence = row.latest_check_in?.confidence
+      latest_check_in.createdAt = new Date(row.latest_check_in?.created_at)
+      latest_check_in.keyResultId = row.latest_check_in?.key_result_id
+      latest_check_in.userId = row.latest_check_in?.user_id
+      latest_check_in.comment = row.latest_check_in?.comment
+      latest_check_in.parentId = row.latest_check_in?.parent_id
+      latest_check_in.previousState = row.latest_check_in?.previous_state
+      latest_check_in.user = row.latest_check_in?.user
+      const row_status: Status = {
+        progress: row?.status?.progress ?? 0,
+        confidence: row?.status?.confidence ?? 0,
+        isOutdated: row.status?.is_outdated,
+        reportDate: new Date(row.latest_check_in?.created_at),
+        isActive: row.is_active,
+        latestCheckIn: latest_check_in,
+      }
+      return {
+        title: row.title,
+        goal: row.goal,
+        initialValue: row.initial_value,
+        createdAt: row.created_at,
+        owner: row.owner,
+        supportTeamMembers: row.supportTeamMembers,
+        objective: row.objective,
+        format: row.format,
+        type: row.type,
+        updatedAt: row.updated_at,
+        ownerId: row.owner_id,
+        objectiveId: row.objective_id,
+        teamId: row.team_id,
+        description: row.description,
+        mode: row.mode,
+        lastUpdatedBy: row.last_updated_by,
+        commentCount: row.comment_count,
+        id: row.id,
+        statuses: row_status,
+      }
+    })
+  }
+}

--- a/src/core/ports/commands/get-user-teams-status.ts
+++ b/src/core/ports/commands/get-user-teams-status.ts
@@ -1,0 +1,96 @@
+import { GetStatusOptions, Status } from '@core/interfaces/status.interface'
+import { CycleInterface } from '@core/modules/cycle/interfaces/cycle.interface'
+
+import { Command } from './base.command'
+// Import { Stopwatch } from '@lib/logger/pino.decorator'
+
+export interface GetTeamStatusOptions extends GetStatusOptions {
+  cycleFilters?: Partial<CycleInterface>
+}
+
+export class GetUserTeamsStatus extends Command<Status[]> {
+  static isActive(keyResults: any[]): boolean {
+    return keyResults.some((keyResult) => keyResult?.objective?.cycle?.active)
+  }
+
+  // @Stopwatch()
+  public async execute(userID: string): Promise<any[]> {
+    const rows = await this.core.entityManager.query(
+      `
+      WITH latest_check_in_by_team AS
+        (SELECT DISTINCT ON (o.team_id) krci.*,
+                            o.team_id
+        FROM public.key_result_check_in krci
+        JOIN public.key_result kr ON krci.key_result_id = kr.id
+        JOIN public.objective o ON kr.objective_id = o.id
+        WHERE o.mode = 'PUBLISHED'
+          AND o.team_id IS NOT NULL
+        ORDER BY o.team_id,
+                  krci.created_at DESC),
+latest_check_in_by_team_with_user as (
+select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as user from latest_check_in_by_team lci join "user" u on lci.user_id = u.id)
+      SELECT t.id, t.name, to_json(ts.*) as status, 
+      ts.progress - ts.previous_progress as delta_progress,
+      ts.confidence - ts.previous_confidence as delta_confidence,
+      to_json(cqac.*) as "tacticalCycle",
+            to_json(lcibt.*) AS last_check_in
+      FROM team_status ts
+      join team t on ts.team_id = t.id
+      join team_current_quarterly_active_cycle cqac on t.id = cqac.t_id
+      join team_company tc on ts.team_id = tc.team_id
+      join user_company uc on tc.company_id = uc.company_id
+      JOIN latest_check_in_by_team_with_user lcibt ON ts.team_id = lcibt.team_id
+ where uc.user_id = $1
+      `,
+      [userID],
+    )
+    const blah = rows.map((row) => {
+      const deltaData = {
+        progress: row.delta_progress,
+        confidence: row.delta_confidence,
+      }
+      return {
+        id: row.id,
+        name: row.name,
+        latestCheckIn: row.last_check_in,
+        status: row.status,
+        delta: deltaData,
+        tacticalCycle: row.tacticalCycle,
+      }
+    })
+
+    return blah // Sipa nao precisa
+
+    // If (Array.isArray(rows) && rows.length === 0) {
+    //   return [
+    //     {
+    //       isOutdated: true,
+    //       isActive: true,
+    //       progress: 0,
+    //       confidence: 100,
+    //     },
+    //   ]
+    // }
+
+    // const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
+    // latest_check_in.id = rows.last_check_in?.id
+    // latest_check_in.value = rows[0].last_check_in?.value
+    // latest_check_in.confidence = rows[0].last_check_in?.confidence
+    // latest_check_in.createdAt = new Date(rows[0].last_check_in?.created_at)
+    // latest_check_in.keyResultId = rows[0].last_check_in?.key_result_id
+    // latest_check_in.userId = rows[0].last_check_in?.user_id
+    // latest_check_in.comment = rows[0].last_check_in?.comment
+    // latest_check_in.parentId = rows[0].last_check_in?.parent_id
+    // latest_check_in.previousState = rows[0].last_check_in?.previous_state
+
+    // const toReturn: Status = {
+    //   isOutdated: rows[0].is_outdated,
+    //   confidence: rows[0].confidence,
+    //   progress: rows[0].progress,
+    //   reportDate: new Date(rows[0].last_check_in?.created_at),
+    //   isActive: rows[0].is_active,
+    //   latestCheckIn: latest_check_in,
+    // }
+    // return blah
+  }
+}

--- a/src/core/ports/commands/get-user-teams-status.ts
+++ b/src/core/ports/commands/get-user-teams-status.ts
@@ -44,7 +44,8 @@ select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as
       `,
       [userID],
     )
-    const blah = rows.map((row) => {
+
+    return rows.map((row) => {
       const deltaData = {
         progress: row.delta_progress,
         confidence: row.delta_confidence,
@@ -58,39 +59,5 @@ select lci.*, concat('{"fullName": "', u.first_name, u.last_name, '"}')::json as
         tacticalCycle: row.tacticalCycle,
       }
     })
-
-    return blah // Sipa nao precisa
-
-    // If (Array.isArray(rows) && rows.length === 0) {
-    //   return [
-    //     {
-    //       isOutdated: true,
-    //       isActive: true,
-    //       progress: 0,
-    //       confidence: 100,
-    //     },
-    //   ]
-    // }
-
-    // const latest_check_in: KeyResultCheckIn = new KeyResultCheckIn()
-    // latest_check_in.id = rows.last_check_in?.id
-    // latest_check_in.value = rows[0].last_check_in?.value
-    // latest_check_in.confidence = rows[0].last_check_in?.confidence
-    // latest_check_in.createdAt = new Date(rows[0].last_check_in?.created_at)
-    // latest_check_in.keyResultId = rows[0].last_check_in?.key_result_id
-    // latest_check_in.userId = rows[0].last_check_in?.user_id
-    // latest_check_in.comment = rows[0].last_check_in?.comment
-    // latest_check_in.parentId = rows[0].last_check_in?.parent_id
-    // latest_check_in.previousState = rows[0].last_check_in?.previous_state
-
-    // const toReturn: Status = {
-    //   isOutdated: rows[0].is_outdated,
-    //   confidence: rows[0].confidence,
-    //   progress: rows[0].progress,
-    //   reportDate: new Date(rows[0].last_check_in?.created_at),
-    //   isActive: rows[0].is_active,
-    //   latestCheckIn: latest_check_in,
-    // }
-    // return blah
   }
 }

--- a/src/core/ports/commands/get-user-teams.command.ts
+++ b/src/core/ports/commands/get-user-teams.command.ts
@@ -1,0 +1,48 @@
+import { Status } from '@core/interfaces/status.interface'
+import { Team } from '@core/modules/team/team.orm-entity'
+
+import { Command } from './base.command'
+// Import { Stopwatch } from '@lib/logger/pino.decorator'
+
+export class GetUserTeams extends Command<Team[]> {
+  static isActive(keyResults: any[]): boolean {
+    return keyResults.some((keyResult) => keyResult?.objective?.cycle?.active)
+  }
+
+  // @Stopwatch()
+  public async execute(userID: string): Promise<any[]> {
+    const rows = await this.core.entityManager.query(
+      `
+      SELECT t.id, t.name, to_json(ts.*) as status, t.description,
+      ts.team_id = tc.company_id as is_company
+      FROM team t
+      left join team_status ts on t.id = ts.team_id
+      join team_company tc on t.id = tc.team_id
+      join team_users_user tuu on t.id = tuu.team_id
+      where tuu.user_id = $1
+      `,
+      [userID],
+    )
+    return rows.map((row) => {
+      const row_status: Status = {
+        progress: row?.status?.progress ?? 0,
+        confidence: row?.status?.confidence ?? 0,
+        isOutdated: row.is_outdated,
+        reportDate: new Date(row.latest_check_in?.created_at),
+        isActive: row.is_active,
+      }
+      return {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        statuses: row_status,
+        is_company: row.is_company ?? false,
+        updatedAt: row.updated_at,
+        ownerId: row.owner_id,
+        createdAt: row.created_at,
+        gender: row.gender,
+        parentId: row.parent_id,
+      }
+    })
+  }
+}

--- a/src/interface/graphql/modules/key-result/key-result.node.ts
+++ b/src/interface/graphql/modules/key-result/key-result.node.ts
@@ -105,6 +105,13 @@ export class KeyResultGraphQLNode implements GuardedNodeGraphQLInterface {
   })
   public status: StatusGraphQLObject
 
+  @Field(() => StatusGraphQLObject, {
+    complexity: 1,
+    description:
+      'The status of the given key-result. Here you can fetch the current progress, confidence, and others for that key-result',
+  })
+  public statuses?: StatusGraphQLObject
+
   @Field(() => DeltaGraphQLObject, {
     complexity: 1,
     description: 'The delta of this key-result comparing with last week',

--- a/src/interface/graphql/modules/team/team.node.ts
+++ b/src/interface/graphql/modules/team/team.node.ts
@@ -56,13 +56,25 @@ export class TeamGraphQLNode implements GuardedNodeGraphQLInterface {
     description:
       'The status of the given team. Here you can fetch the current progress, confidence, and others for that team',
   })
-  public status: StatusGraphQLObject
+  public status?: StatusGraphQLObject
+
+  @Field(() => StatusGraphQLObject, {
+    description:
+      'The status of the given team. Here you can fetch the current progress, confidence, and others for that team',
+  })
+  public statuses?: StatusGraphQLObject
 
   @Field(() => DeltaGraphQLObject, {
     complexity: 2,
     description: 'The delta of this team comparing with last week',
   })
-  public delta!: DeltaGraphQLObject
+  public delta?: DeltaGraphQLObject
+
+  @Field(() => DeltaGraphQLObject, {
+    complexity: 2,
+    description: 'The delta of this team comparing with last week',
+  })
+  public deltas?: DeltaGraphQLObject
 
   @Field(() => UserGraphQLNode, {
     complexity: 1,
@@ -72,6 +84,10 @@ export class TeamGraphQLNode implements GuardedNodeGraphQLInterface {
 
   @Field({ complexity: 1, description: 'Defines if the team is a company' })
   public readonly isCompany?: boolean
+
+  @Field({ complexity: 1, description: 'Defines if the team is a company' })
+  public readonly is_company?: boolean
+
 
   @Field(() => TeamGraphQLNode, {
     complexity: 1,
@@ -94,6 +110,14 @@ export class TeamGraphQLNode implements GuardedNodeGraphQLInterface {
       'Based on the current date, this key defines what is the current active tactical cycle for this team',
   })
   public readonly tacticalCycle?: CycleGraphQLNode
+
+  @Field(() => CycleGraphQLNode, {
+    complexity: 1,
+    nullable: true,
+    description:
+      'Based on the current date, this key defines what is the current active tactical cycle for this team',
+  })
+  public readonly tacticalCycles?: CycleGraphQLNode
 
   // **********************************************************************************************
   // CONNECTION FIELDS

--- a/src/interface/graphql/modules/team/team.resolver.ts
+++ b/src/interface/graphql/modules/team/team.resolver.ts
@@ -217,7 +217,8 @@ export class TeamGraphQLResolver extends GuardedNodeGraphQLResolver<Team, TeamIn
       Team
     >(request)
 
-    const result = await this.corePorts.dispatchCommand<Team[]>(
+    // Alterar esse any para Team + latest Check in, mesma coisa no front
+    const result = await this.corePorts.dispatchCommand<any[]>(
       'get-team-ranked-descendants',
       team.id,
       filters,

--- a/src/interface/graphql/modules/user/user.node.ts
+++ b/src/interface/graphql/modules/user/user.node.ts
@@ -110,6 +110,13 @@ export class UserGraphQLNode implements GuardedNodeGraphQLInterface {
   })
   public readonly ownedTeams?: UserTeamsGraphQLConnection
 
+  @Field(() => UserTeamsGraphQLConnection, {
+    complexity: 0,
+    nullable: true,
+    description: 'The creation date ordered list of teams that this user owns',
+  })
+  public readonly teams_status?: any // Colocar tipo
+
   @Field(() => UserObjectivesGraphQLConnection, {
     complexity: 0,
     nullable: true,

--- a/src/interface/graphql/modules/user/user.node.ts
+++ b/src/interface/graphql/modules/user/user.node.ts
@@ -131,6 +131,13 @@ export class UserGraphQLNode implements GuardedNodeGraphQLInterface {
   })
   public readonly keyResults?: UserKeyResultsGraphQLConnection
 
+  @Field(() => UserKeyResultsGraphQLConnection, {
+    complexity: 0,
+    nullable: true,
+    description: 'The creation date ordered list of key results that this user owns',
+  })
+  public readonly keyResultsStatus?: UserKeyResultsGraphQLConnection
+
   @Field(() => UserKeyResultCommentsGraphQLConnection, {
     complexity: 0,
     nullable: true,

--- a/src/interface/graphql/modules/user/user.resolver.ts
+++ b/src/interface/graphql/modules/user/user.resolver.ts
@@ -330,14 +330,36 @@ export class UserGraphQLResolver extends GuardedNodeGraphQLResolver<User, UserIn
       TeamFiltersRequest,
       Team
     >(request)
-
+    // Console.log(user)
+    // console.log(filters)
+    // console.log(queryOptions)
     const queryResult = await this.core.user.getUserTeams(user, filters, queryOptions)
 
     return this.relay.marshalResponse<TeamInterface>(queryResult, connection, user)
   }
 
-  @Cacheable((request, user) => [user.id, request], 1 * 60)
   @Stopwatch()
+  @ResolveField('teams_status', () => UserTeamsGraphQLConnection)
+  protected async getStatusFromAllTeamsForCycle(
+    @Parent() user: UserGraphQLNode,
+    @Args() request: TeamFiltersRequest,
+  ) {
+    this.logger.log({
+      user,
+      message: 'Fetching current status for all teams of this user',
+    })
+
+    const [_, __, connection] = this.relay.unmarshalRequest<TeamFiltersRequest, Team>(request)
+
+    const result = await this.corePorts.dispatchCommand<any[]>('get-user-teams-status', user.id)
+    if (!result)
+      throw new UserInputError(`We could not find teams status for the user with ID ${user.id}`)
+
+    return this.relay.marshalResponse<TeamInterface>(result, connection, user)
+  }
+
+  @Cacheable((request, user) => [user.id, request], 1 * 60)
+  // @Stopwatch()
   @ResolveField('ownedTeams', () => UserTeamsGraphQLConnection, { nullable: true })
   protected async getOwnedTeamsForRequestAndUser(
     @Args() request: TeamFiltersRequest,

--- a/src/interface/graphql/modules/user/user.resolver.ts
+++ b/src/interface/graphql/modules/user/user.resolver.ts
@@ -358,6 +358,27 @@ export class UserGraphQLResolver extends GuardedNodeGraphQLResolver<User, UserIn
     return this.relay.marshalResponse<TeamInterface>(result, connection, user)
   }
 
+  @Stopwatch()
+  @ResolveField('get_teams', () => UserTeamsGraphQLConnection)
+  protected async getDataFromAllTeams(
+    @Parent() user: UserGraphQLNode,
+    @Args() request: TeamFiltersRequest,
+  ) {
+    this.logger.log({
+      user,
+      message: 'Fetching current status for all teams of this user',
+    })
+
+    const [_, __, connection] = this.relay.unmarshalRequest<TeamFiltersRequest, Team>(request)
+
+    const result = await this.corePorts.dispatchCommand<any[]>('get-user-teams', user.id)
+    if (!result)
+      throw new UserInputError(`We could not find teams status for the user with ID ${user.id}`)
+    console.log(result)
+    console.log('result')
+    return this.relay.marshalResponse<TeamInterface>(result, connection, user)
+  }
+
   @Cacheable((request, user) => [user.id, request], 1 * 60)
   // @Stopwatch()
   @ResolveField('ownedTeams', () => UserTeamsGraphQLConnection, { nullable: true })
@@ -458,6 +479,47 @@ export class UserGraphQLResolver extends GuardedNodeGraphQLResolver<User, UserIn
       ? queryResult.filter((keyResult) => keyResult.teamId !== null)
       : queryResult
     return this.relay.marshalResponse<KeyResultInterface>(filteredResults, connection, user)
+  }
+
+  @Stopwatch()
+  @ResolveField('keyResultsStatus', () => UserKeyResultsGraphQLConnection, { nullable: true })
+  protected async getKeyResultsStatusForRequestAndUser(
+    @Args() request: UserKeyResultsRequest,
+    @Parent() user: UserGraphQLNode,
+  ) {
+    this.logger.log({
+      user,
+      request,
+      message: 'Fetching key results statuses for user',
+    })
+
+    const [options, _, connection] = this.relay.unmarshalRequest<UserKeyResultsRequest, KeyResult>(
+      request,
+    )
+
+    const {
+      active,
+      hasUserCheckMarks,
+      confidence,
+      onlyKeyResultsFromCompany,
+      onlyOwnerKeyResults,
+      ...filters
+    } = options
+    const command = hasUserCheckMarks
+      ? 'get-user-key-results-statuses-with-checkmarks'
+      : 'get-user-key-results-statuses'
+
+    const queryResult = await this.corePorts.dispatchCommand<KeyResultInterface[]>(
+      command,
+      user.id,
+      filters,
+      {
+        active,
+        confidence,
+        onlyOwnerKeyResults,
+      },
+    )
+    return this.relay.marshalResponse(queryResult, connection, user)
   }
 
   @Cacheable('0.id', 5 * 60)


### PR DESCRIPTION
So far, reduced about ~13% of dashboard queries

![Screenshot from 2024-03-23 17-39-08](https://github.com/budproj/business/assets/31250794/424eee2a-5bcf-44b8-88df-0762567f88ac)
![Screenshot from 2024-03-23 17-39-03](https://github.com/budproj/business/assets/31250794/272c75ff-15a0-44ab-83fe-92919ba0b713)
